### PR TITLE
[ENH] copied and stripped issue and pull request templates from nipype

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Summary
+
+### Actual behavior
+
+### Expected behavior
+
+### How to replicate the behavior
+
+### Script/Workflow details
+
+Please put URL to code or code here (if not too long).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
+
+----- REMOVE TILL HERE -----
+
+Fixes # .
+
+Changes proposed in this pull request
+-
+-


### PR DESCRIPTION
Fixes #32 

adds .github directory which *should* read these files and give templates for issues and pull requests