### PR TITLE
[FIX] scriptdir variable

### DIFF
--- a/processRestingState_bids_wrapper.sh
+++ b/processRestingState_bids_wrapper.sh
@@ -90,7 +90,7 @@ do
       esac
  done
 
-scriptdir="$(realpath "${BASH_SOURCE[0]}")"
+scriptdir="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 if [ "${inFile}" == "" ]; then
   echo "ERROR: -i is required flag"


### PR DESCRIPTION
Fixes #53 

Changes proposed in this pull request
- adds dirname to the scriptdir variable so that it refers to the directory instead of the file.