### PR TITLE
[ENH, REF, WIP] removeNuisanceRegressor.sh

### DIFF
--- a/processRestingState_bids_wrapper.sh
+++ b/processRestingState_bids_wrapper.sh
@@ -187,14 +187,14 @@ else
       -v ${fmap_mag} \
       -x ${fmap_mag_stripped} \
       -D ${dwellTime} \
-      -d -y -c
+      -d -y
 
     ${scriptdir}/restingStatePreprocess.sh -E ${rsOut}/mcImg_stripped.nii.gz \
       -A ${T1_RPI_brain} \
       -t 2 \
       -T 30 \
       -s 6 \
-      -f -c
+      -f
 
     ${scriptdir}/removeNuisanceRegressor.sh -E $rsOut/preproc.feat/nonfiltered_smooth_data.nii.gz \
       -A ${T1_RPI_brain} \
@@ -202,7 +202,7 @@ else
       -L .08 \
       -H .008 \
       -t 2 \
-      -T 30 -c
+      -T 30
 
     ${scriptdir}/motionScrub.sh -E $rsOut/RestingState.nii.gz
 
@@ -216,14 +216,13 @@ else
       -A ${T1_RPI_brain} \
       -a ${T1_RPI} \
       -D ${dwellTime} \
-      -d -y -c
+      -d -y
 
     ${scriptdir}/restingStatePreprocess.sh -E ${rsOut}/mcImg_stripped.nii.gz \
       -A ${T1_RPI_brain} \
       -t 2 \
       -T 30 \
       -s 6 \
-      -c
 
     ${scriptdir}/removeNuisanceRegressor.sh -E $rsOut/preproc.feat/nonfiltered_smooth_data.nii.gz \
       -A ${T1_RPI_brain} \
@@ -231,7 +230,7 @@ else
       -L .08 \
       -H .008 \
       -t 2 \
-      -T 30 -c
+      -T 30
 
     ${scriptdir}/motionScrub.sh -E $rsOut/RestingState.nii.gz
 

--- a/removeNuisanceRegressor.sh
+++ b/removeNuisanceRegressor.sh
@@ -170,8 +170,8 @@ while [ $# -ge 1 ] ; do
         fi
   	    shift;;
   	--t1)
-  	    t1SkullData=`get_imarg1 $1`;
-        export t1SkullData;
+  	    t1Data=`get_imarg1 $1`;
+        export t1Data;
         if [ "$t1Data" == "" ]; then
           echo "Error: The T1 image (-A) is a required option"
           exit 1

--- a/removeNuisanceRegressor.sh
+++ b/removeNuisanceRegressor.sh
@@ -154,7 +154,7 @@ function SimultBandpassNuisanceReg()
 
   clobber ${inDir}/"$(basename "${inData%%.nii*}")"_bp_res4d.nii.gz &&\
   rm -rf ${inDir}/*_mean.nii.gz 2> /dev/null &&\
-  rm -rf ${inDir}/tmp_bp.nii.gz 2> /dev/null &&\
+  rm -rf ${inDir}/tmp_bp* 2> /dev/null &&\
 	3dTproject -input ${inData} -prefix $inDir/tmp_bp.nii.gz -mask ${mask} -bandpass ${fbot} ${ftop} -ort ${regressorsFile} -verb &&\
   # add mean back in
 	3dTstat -mean -prefix $inDir/orig_mean.nii.gz ${inData} &&\

--- a/removeNuisanceRegressor.sh
+++ b/removeNuisanceRegressor.sh
@@ -161,9 +161,9 @@ function SimultBandpassNuisanceReg()
 	3dTstat -mean -prefix $inDir/bp_mean.nii.gz $inDir/tmp_bp.nii.gz &&\
 	3dcalc -a $inDir/tmp_bp.nii.gz -b $inDir/orig_mean.nii.gz -c $inDir/bp_mean.nii.gz -expr "a+b-c" -prefix ${inDir}/"$(basename "${inData%%.nii*}")"_bp_res4d.nii.gz
 
-  echo "lowpassFilt=$ftop" >> $logDir/aromaParams
-  echo "highpassFilt=$fbot" >> $logDir/aromaParams
-  echo "_${filtType}" >> $logDir/aromaParams
+  echo "lowpassFilt=$ftop" >> $logDir/rsParams
+  echo "highpassFilt=$fbot" >> $logDir/rsParams
+  echo "_${filtType}" >> $logDir/rsParams
 }
 export -f SimultBandpassNuisanceReg
 

--- a/removeNuisanceRegressor.sh
+++ b/removeNuisanceRegressor.sh
@@ -18,7 +18,7 @@ function Usage {
   echo "Usage: removeNuisanceRegressor.sh --epi=restingStateImage --t1brain=T1Image --nuisanceList=nuisanceList.txt --tr=tr --te=te --hp=highpass --lp=lowpass --compcor -c"
   echo ""
   echo " where"
-  echo "  -epi preprocessed Resting State file"
+  echo "  --epi preprocessed Resting State file"
   echo "     *If using 'Classic' mode (no ICA Denoising), specify 'nonfiltered_func_data.nii.gz' from preproc.feat directory"
   echo "     *If using ICA_AROMA, use denoised_func_data_nonaggr.nii.gz from ica_aroma directory"
   echo "  --t1brain T1 file (skull-stripped)"

--- a/removeNuisanceRegressor.sh
+++ b/removeNuisanceRegressor.sh
@@ -432,20 +432,18 @@ export regressorsFile
 clobber ${indir}/"$(basename "${epiData%%.nii*}")"_bp_res4d.nii.gz &&\
 SimultBandpassNuisanceReg ${epiData} $indir/mcImgMean_mask.nii.gz
 
-epiDataFilt=${indir}/"$(basename "${epiData%%.nii*}")"_bp.nii.gz
-export epiDataFilt
+epiDataFiltReg=${indir}/"$(basename "${epiData%%.nii*}")"_bp_res4d.nii.gz
+export epiDataFiltReg
 
 
 
 
 
-###### Post-FEAT data-scaling ########################################
-
-cd "$indir"/"${nuisancefeat}"/stats || exit
+###### Post-regression data-scaling ########################################
 
 # Backup file
 echo "...Scaling data by 1000"
-cp res4d.nii.gz res4d_orig.nii.gz
+cp ${epiDataFiltReg} ${epiDataFiltReg/res4d/res4d_orig}
 
 # For some reason, this mask isn't very good.  Use the good mask top-level
 echo "...Copy Brain mask"
@@ -454,14 +452,14 @@ fslmaths mask -mul 1000 mask1000 -odt float
 
 # normalize res4d here
 echo "...Normalize Data"
-fslmaths res4d -Tmean res4d_tmean
-fslmaths res4d -Tstd res4d_std
-fslmaths res4d -sub res4d_tmean res4d_dmean
-fslmaths res4d_dmean -div res4d_std res4d_normed
-fslmaths res4d_normed -add mask1000 res4d_normandscaled -odt float
+fslmaths ${epiDataFiltReg} -Tmean ${epiDataFiltReg/res4d/res4d_tmean} res4d_tmean
+fslmaths ${epiDataFiltReg} -Tstd ${epiDataFiltReg/res4d/res4d_std}res4d_std
+fslmaths ${epiDataFiltReg} -sub ${epiDataFiltReg/res4d/res4d_tmean} ${epiDataFiltReg/res4d/res4d_dmean} res4d_tmean res4d_dmean
+fslmaths ${epiDataFiltReg/res4d/res4d_dmean} -div ${epiDataFiltReg/res4d/res4d_std} ${epiDataFiltReg/res4d/res4d_normed}
+fslmaths ${epiDataFiltReg/res4d/res4d_normed} -add mask1000 ${epiDataFiltReg/res4d/res4d_normandscaled} -odt float
 
 # Echo out final file to rsParams file
-echo "epiNorm=$indir/$nuisancefeat/stats/res4d_normandscaled.nii.gz" >> "$logDir"/rsParams
+echo "epiNorm=${epiDataFiltReg/res4d/res4d_normed}" >> "$logDir"/rsParams
 
 #################################
 

--- a/removeNuisanceRegressor.sh
+++ b/removeNuisanceRegressor.sh
@@ -105,7 +105,7 @@ function clobber()
 	#clobber test.nii.gz &&\
 	#fslmaths input.nii.gz -mul 10 test.nii.gz
 }
-#default
+# default
 clob=false
 export -f clobber
 
@@ -118,12 +118,12 @@ function SimultBandpassNuisanceReg()
   local inDir
   inDir=$(dirname ${inData})
 
-  #If neither lowpass or highpass is set, do an allpass filter (fbot=0 ftop=99999)
-   #If ONLY highpass is set, do a highpass filter (fbot=${hp} ftop=99999)
-   #If ONLY lowpass is set, do a lowpass filter (fbot=0 ftop=${hp})
-   #If both lowpass and highpass are set, do a bandpass filter (fbot=${hp} ftop=${lp})
+   # If neither lowpass or highpass is set, do an allpass filter (fbot=0 ftop=99999)
+   # If ONLY highpass is set, do a highpass filter (fbot=${hp} ftop=99999)
+   # If ONLY lowpass is set, do a lowpass filter (fbot=0 ftop=${hp})
+   # If both lowpass and highpass are set, do a bandpass filter (fbot=${hp} ftop=${lp})
   if [[ $lp == ""  &&  $hp == "" ]]; then
-    ##allpass filter
+    # allpass filter
     fbot=0
     ftop=99999
     hp=0
@@ -131,21 +131,21 @@ function SimultBandpassNuisanceReg()
     filtType=allpass
     echo "Performing an 'allpass' filter.  Removal of '0' and Nyquist only."
   elif [[ $lp == ""  &&  $hp != "" ]]; then
-    ##highpass filter
+    # highpass filter
     fbot=${hp}
     ftop=99999
     lp=99999
     filtType=highpass
     echo "Performing a 'highpass' filter.  Frequencies below ${hp} will be filtered."
   elif [[ $lp != ""  &&  $hp == "" ]]; then
-    ##lowpass filter
+    # lowpass filter
     fbot=0
     ftop=${lp}
     hp=0
     filtType=lowpass
     echo "Performing a 'lowpass' filter.  Frequencies above ${lp} will be filtered."
   else
-    ##bandpass filter (low and high)
+    # bandpass filter (low and high)
     fbot=${hp}
     ftop=${lp}
     filtType=bandpass

--- a/removeNuisanceRegressor.sh
+++ b/removeNuisanceRegressor.sh
@@ -44,7 +44,8 @@ function Usage {
   echo "     still be removed (allpass filter)"
   echo "  --tr TR time (seconds)"
   echo "  --te TE (milliseconds) (default to 30 ms)"
-  echo "  -a flag if using ICA_AROMA denoised data as input to nuisancereg"
+  echo "  --aroma flag if using ICA_AROMA denoised data as input to nuisancereg"
+  echo "  --compcor flag if using CompCor nuisancereg"
   echo "  -c clobber/overwrite previous results"
   echo ""
   echo "Existing nuisance ROIs:"
@@ -201,7 +202,7 @@ while [ $# -ge 1 ] ; do
       compcorFlag=1;
       export compcorFlag;
       shift;;
-    -a)
+    --aroma)
       aromaFlag=1;
       export aromaFlag;
       shift;;
@@ -230,15 +231,6 @@ if [ "$FSLDIR" == "" ]; then
   exit 1
 fi
 
-for roi in "${nuisanceList[@]}"
-do
-  testRoi=$(echo "$knownNuisanceRois" | grep "$roi")
-  if [ "$testRoi" == "" ]; then
-    echo "Error: Invalid Nuisance ROI specified (${roi})"
-    echo "Valid Nuisance ROIs: $knownNuisanceRois"
-    exit 1
-  fi
-done
 
 if [[ "${nuisanceList[*]}" == "" ]]; then
   echo "Error: At least one Nuisance ROI must be specified using the -n options"

--- a/removeNuisanceRegressor.sh
+++ b/removeNuisanceRegressor.sh
@@ -13,18 +13,17 @@
 SGE_ROOT='';export SGE_ROOT
 
 function Usage {
-  echo "Usage: removeNuisanceRegressor.sh --epi=restingStateImage --t1brain=T1Image --nuisanceMode=nuisanceMode --tr=tr --te=te --hp=highpass --lp=lowpass -c"
+  echo "Usage: removeNuisanceRegressor.sh --epi=restingStateImage --t1brain=T1Image --nuisanceList=nuisanceList.txt --tr=tr --te=te --hp=highpass --lp=lowpass -c"
   echo "            -OR-"
-  echo "Usage: removeNuisanceRegressor.sh -E restingStateImage -A T1Image -n nuisanceROI -t tr -T te -H highpass -L lowpass -M -c"
+  echo "Usage: removeNuisanceRegressor.sh --epi=restingStateImage --t1brain=T1Image --nuisanceList=nuisanceList.txt --tr=tr --te=te --hp=highpass --lp=lowpass --compcor -c"
   echo ""
   echo " where"
   echo "  -epi preprocessed Resting State file"
   echo "     *If using 'Classic' mode (no ICA Denoising), specify 'nonfiltered_func_data.nii.gz' from preproc.feat directory"
   echo "     *If using ICA_AROMA, use denoised_func_data_nonaggr.nii.gz from ica_aroma directory"
   echo "  --t1brain T1 file (skull-stripped)"
-  echo "     *T1 should be from output of dataPrep script, EPI shoule be from output of ICA_denoise script"
   echo "  --nuisanceList list containing paths to nuisance ROIs"
-  echo "      compcor = ICA-AROMA + WM/CSF regressors derived from FAST segmentation"
+  echo "      compcor = WM/CSF regressors derived from FAST segmentation"
   echo "      classic = global + WM roi + CSF roi"
   echo "  --lp lowpass filter frequency (Hz) (e.g. 0.08 Hz (2.5 sigma))"
   echo "  --hp highpass filter frequency (Hz) (e.g. 0.008 Hz (25.5 sigma / 120 s))"
@@ -32,9 +31,8 @@ function Usage {
   echo "     still be removed (allpass filter)"
   echo "  --tr TR time (seconds)"
   echo "  --te TE (milliseconds) (default to 30 ms)"
-  echo "  --aroma flag if using ICA_AROMA denoised data as input to nuisancereg"
   echo "  --compcor flag if using CompCor nuisancereg"
-  echo "  -c clobber/overwrite previous results"
+  echo "  --clobber clobber/overwrite previous results"
   echo ""
   exit 1
 }
@@ -224,11 +222,7 @@ while [ $# -ge 1 ] ; do
       compcorFlag=1;
       export compcorFlag;
       shift;;
-    --aroma)
-      aromaFlag=1;
-      export aromaFlag;
-      shift;;
-    -c)
+    --clobber)
       clob=true;
       export clob;
       shift;;

--- a/removeNuisanceRegressor.sh
+++ b/removeNuisanceRegressor.sh
@@ -32,7 +32,7 @@ function Usage {
   echo " where"
   echo "  -epi preprocessed Resting State file"
   echo "     *If using 'Classic' mode (no ICA Denoising), specify 'nonfiltered_func_data.nii.gz' from preproc.feat directory"
-  echo "     *If using ICA_AROMA, use denoised_func_data_aggr.nii.gz from ica_aroma directory"
+  echo "     *If using ICA_AROMA, use denoised_func_data_nonaggr.nii.gz from ica_aroma directory"
   echo "  --t1brain T1 file (skull-stripped)"
   echo "     *T1 should be from output of dataPrep script, EPI shoule be from output of ICA_denoise script"
   echo "  --nuisanceList list containing paths to nuisance ROIs"
@@ -163,7 +163,7 @@ while [ $# -ge 1 ] ; do
         Usage;
         exit 0;;
     --epi)
-  	    epiData=`get_imarg1 $1`;
+  	    epiData=`get_arg1 $1`;
         export epiData;
         if [ "$epiData" == "" ]; then
           echo "Error: The restingStateImage (-E) is a required option"

--- a/removeNuisanceRegressor.sh
+++ b/removeNuisanceRegressor.sh
@@ -169,17 +169,13 @@ while [ $# -ge 1 ] ; do
           exit 1
         fi
   	    shift;;
-  	--t1)
+  	--t1brain)
   	    t1Data=`get_imarg1 $1`;
         export t1Data;
         if [ "$t1Data" == "" ]; then
           echo "Error: The T1 image (-A) is a required option"
           exit 1
         fi
-  	    shift;;
-    --t1brain)
-  	    t1Data=`get_imarg1 $1`;
-        export t1Data;
   	    shift;;
     --nuisanceList)
       nuisanceList=( "$(cat "$(get_arg1 $1)")" );

--- a/roiList_tmp.txt
+++ b/roiList_tmp.txt
@@ -1,0 +1,1 @@
+/Users/tbweng/Documents/GitHub/RestingState/ROIs/Schaefer2018_LocalGlobal_MNI/MNI152_T1_1mm_brain.nii.gz


### PR DESCRIPTION
ENH, REF, WIP

Changes proposed in this pull request
- improve argument parsing
- decrease repeat code by using clobber function
- add flag for data denoised with ica_aroma
- add flag for CompCor nuisance regression

 ```
# first make sure in right branch
git checkout enh_removeNuisanceRegressor.sh

# example call for compcor-like regression (5 wm + 5 csf)
bash ~/Documents/git/RestingState/removeNuisanceRegressor.sh \
--epi=/Users/tbweng/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/test/sub-GEA161_ses-activepre/ica_aroma/denoised_func_data_nonaggr.nii.gz \
--t1brain=/Users/tbweng/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/MBA/sub-GEA161/ses-activepre/sub-GEA161_ses-activepre_T1w_brain.nii.gz \
--nuisanceList=/Users/tbweng/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/test/nuisanceList.txt \
--compcor --aroma \
--tr=2 --te=30 \
--hp=.008 --lp=.08

# example call for classic nuisance reg (global + wm roi + csf roi + 6 motion params):
bash ~/Documents/git/RestingState/removeNuisanceRegressor.sh \
--epi=/Users/tbweng/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/test/sub-GEA161_ses-activepre/preproc.feat/nonfiltered_smooth_data.nii.gz \
--t1brain=/Users/tbweng/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/MBA/sub-GEA161/ses-activepre/sub-GEA161_ses-activepre_T1w_brain.nii.gz \
--nuisanceList=/Users/tbweng/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/test/nuisanceList_classic.txt \
--tr=2 --te=30 \
--hp=.008 --lp=.08
```