### PR TITLE
[WIP, ENH, STY, REF] Refactor seedVoxelCorrelation.sh

### DIFF
--- a/firstlevelseeding_parallel.m
+++ b/firstlevelseeding_parallel.m
@@ -1,4 +1,4 @@
-function firstlevelseeding_parallel(subPath,roiList,featdir,funcvoldim,input,motion_scrub,doFisherZ)
+function firstlevelseeding_parallel(subPath,roiList,roiOutDir,funcvoldim,input,motion_scrub,doFisherZ)
 
 %script to calculate correlation coefficient between a set of seed
 %timecourses and a functional volume that has had nuisance signals
@@ -52,7 +52,7 @@ imagedimsz=funcvoldim(3);
 
 numclusters = parcluster('local'); %find the number of workers available on your machine/server
 
-if roiN <= 4    
+if roiN <= 4
     dcpoolsize = roiN; %for cases when there's only 1 or 2 ROIs
 elseif numclusters.NumWorkers > 4
     dcpoolsize = numclusters.NumWorkers-2; %if you have more than 4 workers available, set pool size to N-2, limits tying up server
@@ -72,7 +72,7 @@ catch err
 end
 
 warning off all
-mypath=[subPath,'/',featdir,'/stats'];
+mypath=[roiOutDir];
 cd(mypath);
 
 if exist('cope1.nii.gz','file')
@@ -97,7 +97,7 @@ totalslices=imagedimsx*roiN;
 
 
 parfor r=1:roiN
-  
+
   fcmap=zeros(imagedimsx,imagedimsy,imagedimsz);
 
   if (motion_scrub==1)
@@ -105,12 +105,12 @@ parfor r=1:roiN
   else
     seedts=load([char(roiList{1,1}(r)),'_','residvol_ts.txt']);
   end
-  % Loop over three dims - x y z 
+  % Loop over three dims - x y z
   for a=1:imagedimsx;
-    
+
     %fprintf(1, '%3d%% \n',int8(index/totalslices*100.0));
     %index = index +1
-    
+
     for b=1:imagedimsy;
       for c=1:imagedimsz;
         %calc correlation bewteen seed timeseries and timeseries of that voxel; tmp=2x2 symmetric corr table
@@ -130,7 +130,7 @@ parfor r=1:roiN
         end
 
         %fill voxel with correlation coefficient
-        fcmap(a,b,c)=pixr; 
+        fcmap(a,b,c)=pixr;
       end
     end
   end
@@ -164,12 +164,5 @@ parfor r=1:roiN
     system(['rm',' ', [char(roiList{1,1}(r)) '_cope1.nii']]);
     fprintf(1,'%s Done \n',[char(roiList{1,1}(r))]);
   end
- 
+
 end
-
-
-
-
-
-
-

--- a/firstlevelseeding_parallel.m
+++ b/firstlevelseeding_parallel.m
@@ -1,4 +1,4 @@
-function firstlevelseeding_parallel(subPath,roiList,roiOutDir,funcvoldim,input,motion_scrub,doFisherZ)
+function firstlevelseeding_parallel(roiList,roiOutDir,funcvoldim,input,motion_scrub,doFisherZ)
 
 %script to calculate correlation coefficient between a set of seed
 %timecourses and a functional volume that has had nuisance signals
@@ -75,9 +75,9 @@ warning off all
 mypath=[roiOutDir];
 cd(mypath);
 
-if exist('cope1.nii.gz','file')
-  system('gunzip cope1.nii.gz')
-end
+%if exist('cope1.nii.gz','file')
+%  system('gunzip cope1.nii.gz')
+%end
 
 funcon=load_untouch_nii(input);
 func=funcon.img;

--- a/seedVoxelCorrelation.sh
+++ b/seedVoxelCorrelation.sh
@@ -535,15 +535,12 @@ if [ "${seedmapFlag}" -eq 1 ]; then
 
   if [[ $motionscrubFlag == 0 ]]; then
 
-  # If $motionscrubFlag == 0 (no motionscrub), res4dnormandscaled never gets unzipped
-  if [ -e ${rawEpiDir}/res4d_normandscaled.nii.gz ] && [ ${rawEpiDir}/res4d_normandscaled.nii ]; then
-  	rm ${rawEpiDir}/res4d_normandscaled.nii
-  	gunzip -f ${rawEpiDir}/res4d_normandscaled.nii.gz
-  fi
+    # If $motionscrubFlag == 0 (no motionscrub), res4dnormandscaled never gets unzipped
+  	clobber "${epiData/.nii.gz/.nii}" &&\
+  	gunzip -f ${epiData}
 
-
-  echo "...Creating Octave script"
-  cat > $filename << EOF
+    echo "...Creating Octave script"
+    cat > $filename << EOF
 % It is matlab script
 addpath('${scriptDir}')
 statsScripts=['${scriptDir}','/Octave/nifti'];
@@ -555,15 +552,15 @@ fclose(fid);
 funcvoldim=[$numXdim $numYdim ${numZdim}];
 doFisherZ=1;
 motion_scrub=0;
-input='res4d_normandscaled.nii';
+input='${epiData/.nii.gz/.nii}';
 
-firstlevelseeding_parallel('$rawEpiDir',roiList,'$roiOutDir',funcvoldim,input,motion_scrub,doFisherZ)
+firstlevelseeding_parallel(roiList,'$roiOutDir',funcvoldim,input,motion_scrub,doFisherZ)
 quit
 EOF
   elif [[ $motionscrubFlag == 1 ]]; then
 
-  echo "...Creating Octave script (motionscrubbed data)"
-  cat > $filename2 << EOF
+    echo "...Creating Octave script (motionscrubbed data)"
+    cat > $filename2 << EOF
 % It is matlab script
 addpath('${scriptDir}')
 statsScripts=['${scriptDir}','/Octave/nifti'];
@@ -575,15 +572,15 @@ fclose(fid);
 funcvoldim=[$numXdim $numYdim ${numZdim}];
 doFisherZ=1;
 motion_scrub=1;
-input='res4d_normandscaled_motionscrubbed.nii';
+input='${epiData/.nii.gz/_ms.nii}';
 
 firstlevelseeding_parallel('$rawEpiDir',roiList,'$roiOutDir',funcvoldim,input,motion_scrub,doFisherZ)
 quit
 EOF
   else
 
-  echo "...Creating Octave script"
-  cat > $filename << EOF
+    echo "...Creating Octave script"
+    cat > $filename << EOF
 % It is matlab script
 addpath('${scriptDir}')
 statsScripts=['${scriptDir}','/Octave/nifti'];
@@ -595,7 +592,7 @@ fclose(fid);
 funcvoldim=[$numXdim $numYdim ${numZdim}];
 doFisherZ=1;
 motion_scrub=0;
-input='res4d_normandscaled.nii';
+input='${epiData/.nii.gz/.nii}';
 
 firstlevelseeding_parallel('$rawEpiDir',roiList,'$roiOutDir',funcvoldim,input,motion_scrub,doFisherZ)
 quit
@@ -614,7 +611,7 @@ fclose(fid);
 funcvoldim=[$numXdim $numYdim ${numZdim}];
 doFisherZ=1;
 motion_scrub=1;
-input='res4d_normandscaled_motionscrubbed.nii';
+input='${epiData/.nii.gz/_ms.nii}';
 
 firstlevelseeding_parallel('$rawEpiDir',roiList,'$roiOutDir',funcvoldim,input,motion_scrub,doFisherZ)
 quit

--- a/seedVoxelCorrelation.sh
+++ b/seedVoxelCorrelation.sh
@@ -510,17 +510,17 @@ if [ "${seedmapFlag}" -eq 1 ]; then
 
   # check if seeding results exist, re-populate seeds.txt with non existing seeds
   for roi in $(cat "$rawEpiDir"/seeds_orig.txt); do
-  	if [[ $motionscrubFlag == 1 ]] && [ ! -f ${rawEpiDir}/${roi}_ms/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_ms_standard_zmap.nii.gz ]; then
+  	if [[ $motionscrubFlag == 1 ]] && [ ! -f ${roiOutDir}/${roi}_ms/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_ms_standard_zmap.nii.gz ]; then
   		echo $roi >> "$rawEpiDir"/seeds_ms.txt
   	fi
-  	if [[ $motionscrubFlag == 0 ]] && [ ! -f ${rawEpiDir}/${roi}/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_standard_zmap.nii.gz ]; then
+  	if [[ $motionscrubFlag == 0 ]] && [ ! -f ${roiOutDir}/${roi}/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_standard_zmap.nii.gz ]; then
   		echo $roi >> "$rawEpiDir"/seeds.txt
   	fi
   	if [[ $motionscrubFlag == 2 ]]; then
-  		if [ ! -f ${rawEpiDir}/${roi}/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_standard_zmap.nii.gz ]; then
+  		if [ ! -f ${roiOutDir}/${roi}/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_standard_zmap.nii.gz ]; then
   			echo $roi >> "$rawEpiDir"/seeds.txt
   		fi
-  		if [ ! -f ${rawEpiDir}/${roi}_ms/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_ms_standard_zmap.nii.gz ]; then
+  		if [ ! -f ${roiOutDir}/${roi}_ms/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_ms_standard_zmap.nii.gz ]; then
   			echo $roi >> "$rawEpiDir"/seeds_ms.txt
   		fi
   	fi
@@ -638,12 +638,12 @@ EOF
     		fi
   	  else
     		if [[ $motionscrubFlag == 0 ]]; then
-    		    matlab -nodisplay -r "run "$rawEpiDir"/$filename"
+    		    matlab -nodisplay -r "run $rawEpiDir/$filename"
     		elif [[ $motionscrubFlag == 1 ]]; then
-    		    matlab -nodisplay -r "run "$rawEpiDir"/$filename2"
+    		    matlab -nodisplay -r "run $rawEpiDir/$filename2"
     		else
-    		    matlab -nodisplay -r "run "$rawEpiDir"/$filename"
-    		    matlab -nodisplay -r "run "$rawEpiDir"/$filename2"
+    		    matlab -nodisplay -r "run $rawEpiDir/$filename"
+    		    matlab -nodisplay -r "run $rawEpiDir/$filename2"
     		fi
       fi
   else
@@ -660,13 +660,13 @@ EOF
 
   # Copy over anatomical files to results directory
   # T1 (highres)
-  cp "$rawEpiDir"/${preprocfeat}/reg/highres.nii.gz ${seedcorrDir}
+  cp ${preprocfeat}/reg/highres.nii.gz ${seedcorrDir}
 
   # T1toMNI (highres2standard)
-  cp "$rawEpiDir"/${preprocfeat}/reg/highres2standard.nii.gz ${seedcorrDir}
+  cp ${preprocfeat}/reg/highres2standard.nii.gz ${seedcorrDir}
 
   # MNI (standard)
-  cp "$rawEpiDir"/${preprocfeat}/reg/standard.nii.gz ${seedcorrDir}
+  cp ${preprocfeat}/reg/standard.nii.gz ${seedcorrDir}
 
 
   # HTML setup
@@ -684,10 +684,10 @@ EOF
 
       # Nonlinear warp from EPI to MNI
       clobber ${seedcorrDir}/${roi}_standard_zmap.nii.gz &&\
-      applywarp --in=${rawEpiDir}/${roi}/cope1.nii \
-      --ref="$rawEpiDir"/${preprocfeat}/reg/standard.nii.gz \
+      applywarp --in=${roiOutDir}/${roi}/cope1.nii \
+      --ref=${preprocfeat}/reg/standard.nii.gz \
       --out=${seedcorrDir}/${roi}_standard_zmap.nii.gz \
-      --warp="$rawEpiDir"/${preprocfeat}/reg/example_func2standard_warp.nii.gz \
+      --warp=${preprocfeat}/reg/example_func2standard_warp.nii.gz \
       --datatype=float
 
       # Mask out data with MNI mask
@@ -695,21 +695,21 @@ EOF
 
       # Warp seed from MNI to T1
       clobber ${seedcorrDir}/${roi}_highres.nii.gz &&\
-      applywarp --in=${seedcorrDir}/${roi}_standard.nii.gz \
-      --ref="$rawEpiDir"/${preprocfeat}/reg/highres.nii.gz \
+      applywarp --in=${roiOutDir}/${roi}_standard.nii.gz \
+      --ref=${preprocfeat}/reg/highres.nii.gz \
       --out=${seedcorrDir}/${roi}_highres.nii.gz \
-      --warp="$rawEpiDir"/${preprocfeat}/reg/standard2highres_warp.nii.gz \
+      --warp=${preprocfeat}/reg/standard2highres_warp.nii.gz \
       --interp=nn
 
       # Creating new plots with fsl_tsplot
       # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
-      yMax=$(cat ${rawEpiDir}/${roi}_residvol_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
-      yMin=$(cat ${rawEpiDir}/${roi}_residvol_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
+      yMax=$(cat ${roiOutDir}/${roi}_residvol_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
+      yMin=$(cat ${roiOutDir}/${roi}_residvol_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
 
-      clobber "$rawEpiDir"/${roi}.png &&\
-      fsl_tsplot -i ${rawEpiDir}/${roi}_residvol_ts.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$rawEpiDir"/${roi}.png
+      clobber "$roiOutDir"/${roi}.png &&\
+      fsl_tsplot -i ${roiOutDir}/${roi}_residvol_ts.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$roiOutDir"/${roi}.png
 
-      echo "<br><img src=\"$rawEpiDir/${roi}.png\" alt=\"$roi seed\"><br>" >> "$rawEpiDir"/analysisResults.html
+      echo "<br><img src=\"$roiOutDir/${roi}.png\" alt=\"$roi seed\"><br>" >> "$rawEpiDir"/analysisResults.html
 
     elif [[ $motionscrubFlag == 1 ]]; then
       # Only motionscrubbed data
@@ -719,11 +719,11 @@ EOF
 
 
       # Nonlinear warp from EPI to MNI
-      clobber ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz &&\
-      applywarp --in=${rawEpiDir}/${roi}_ms/cope1.nii \
-      --ref="$rawEpiDir"/${preprocfeat}/reg/standard.nii.gz \
+      clobber ${roiOutDir}/${roi}_ms_standard_zmap.nii.gz &&\
+      applywarp --in=${roiOutDir}/${roi}_ms/cope1.nii \
+      --ref=${preprocfeat}/reg/standard.nii.gz \
       --out=${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz \
-      --warp="$rawEpiDir"/${preprocfeat}/reg/example_func2standard_warp.nii.gz \
+      --warp=${preprocfeat}/reg/example_func2standard_warp.nii.gz \
       --datatype=float
 
       # Mask out data with MNI mask
@@ -731,10 +731,10 @@ EOF
 
       # Warp seed from MNI to T1
       clobber ${seedcorrDir}/${roi}_highres.nii.gz &&\
-      applywarp --in=${seedcorrDir}/${roi}_standard.nii.gz \
-      --ref="$rawEpiDir"/${preprocfeat}/reg/highres.nii.gz \
+      applywarp --in=${roiOutDir}/${roi}_standard.nii.gz \
+      --ref=${preprocfeat}/reg/highres.nii.gz \
       --out=${seedcorrDir}/${roi}_highres.nii.gz \
-      --warp="$rawEpiDir"/${preprocfeat}/reg/standard2highres_warp.nii.gz \
+      --warp=${preprocfeat}/reg/standard2highres_warp.nii.gz \
       --interp=nn
 
 
@@ -746,41 +746,41 @@ EOF
 
         # Creating new plots with fsl_tsplot
         # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
-        yMax=$(cat ${rawEpiDir}/${roi}_residvol_ms_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
-        yMin=$(cat ${rawEpiDir}/${roi}_residvol_ms_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
+        yMax=$(cat ${roiOutDir}/${roi}_residvol_ms_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
+        yMin=$(cat ${roiOutDir}/${roi}_residvol_ms_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
 
         # Log the "scrubbed TRs"
-        xNum=$(cat ${rawEpiDir}/${roi}_residvol_ms_ts.txt | wc -l)
+        xNum=$(cat ${roiOutDir}/${roi}_residvol_ms_ts.txt | wc -l)
         count=1
         while [ $count -le $xNum ]; do
-          tsPlotIn=$(cat ${rawEpiDir}/${roi}_residvol_ms_ts.txt | head -${count} | tail -1)
+          tsPlotIn=$(cat ${roiOutDir}/${roi}_residvol_ms_ts.txt | head -${count} | tail -1)
           delPlotCheck=$(cat ${rawEpiDir}/deleted_vols.txt | awk '{$1=$1}1' | grep -E '(^| )'${count}'( |$)')
           if [ "$delPlotCheck" == "" ]; then
             delPlot=$yMin
           else
             delPlot=$yMax
           fi
-          echo $delPlot >> ${rawEpiDir}/${roi}_censored_TRplot.txt
+          echo $delPlot >> ${roiOutDir}/${roi}_censored_TRplot.txt
         let count=count+1
         done
 
         #Plot of "scrubbed" data
-        clobber "$rawEpiDir"/${roi}_ms.png &&\
-        fsl_tsplot -i ${rawEpiDir}/${roi}_residvol_ms_ts.txt -t "$roi Time Series (Scrubbed)" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$rawEpiDir"/${roi}_ms.png
+        clobber "$roiOutDir"/${roi}_ms.png &&\
+        fsl_tsplot -i ${roiOutDir}/${roi}_residvol_ms_ts.txt -t "$roi Time Series (Scrubbed)" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$roiOutDir"/${roi}_ms.png
 
-        echo "<br><img src=\"$rawEpiDir/${roi}.png\" alt=\"${roi} seed\"><img src=\"$rawEpiDir/${roi}_ms.png\" alt=\"${roi}_ms seed\"><br>" >> "$rawEpiDir"/analysisResults.html
+        echo "<br><img src=\"$roiOutDir/${roi}.png\" alt=\"${roi} seed\"><img src=\"$roiOutDir/${roi}_ms.png\" alt=\"${roi}_ms seed\"><br>" >> "$rawEpiDir"/analysisResults.html
 
       else
         # Absence of scrubbed volumes
 
         # Creating new plots with fsl_tsplot
         # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
-        yMax=$(cat ${rawEpiDir}/${roi}_residvol_ms_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
-        yMin=$(cat ${rawEpiDir}/${roi}_residvol_ms_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
+        yMax=$(cat ${roiOutDir}/${roi}_residvol_ms_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
+        yMin=$(cat ${roiOutDir}/${roi}_residvol_ms_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
 
-        fsl_tsplot -i ${rawEpiDir}/${roi}_residvol_ms_ts.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$rawEpiDir"/${roi}.png
+        fsl_tsplot -i ${roiOutDir}/${roi}_residvol_ms_ts.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$roiOutDir"/${roi}.png
 
-        echo "<br><img src=\"$rawEpiDir/${roi}.png\" alt=\"$roi seed\"><br>" >> "$rawEpiDir"/analysisResults.html
+        echo "<br><img src=\"$roiOutDir/${roi}.png\" alt=\"$roi seed\"><br>" >> "$rawEpiDir"/analysisResults.html
       fi
 
     else
@@ -794,10 +794,10 @@ EOF
 
       # Nonlinear warp from EPI to MNI
       clobber ${seedcorrDir}/${roi}_standard_zmap.nii.gz &&\
-      applywarp --in=${rawEpiDir}/${roi}/cope1.nii \
-      --ref="$rawEpiDir"/${preprocfeat}/reg/standard.nii.gz \
+      applywarp --in=${roiOutDir}/${roi}/cope1.nii \
+      --ref=${preprocfeat}/reg/standard.nii.gz \
       --out=${seedcorrDir}/${roi}_standard_zmap.nii.gz \
-      --warp="$rawEpiDir"/${preprocfeat}/reg/example_func2standard_warp.nii.gz \
+      --warp=${preprocfeat}/reg/example_func2standard_warp.nii.gz \
       --datatype=float
 
       # Mask out data with MNI mask
@@ -805,10 +805,10 @@ EOF
 
       # Warp seed from MNI to T1
       clobber ${seedcorrDir}/${roi}_highres.nii.gz &&\
-      applywarp --in=${seedcorrDir}/${roi}_standard.nii.gz \
-      --ref="$rawEpiDir"/${preprocfeat}/reg/highres.nii.gz \
+      applywarp --in=${roiOutDir}/${roi}_standard.nii.gz \
+      --ref=${preprocfeat}/reg/highres.nii.gz \
       --out=${seedcorrDir}/${roi}_highres.nii.gz \
-      --warp="$rawEpiDir"/${preprocfeat}/reg/standard2highres_warp.nii.gz \
+      --warp=${preprocfeat}/reg/standard2highres_warp.nii.gz \
       --interp=nn
 
 
@@ -816,10 +816,10 @@ EOF
 
       # Nonlinear warp from EPI to MNI
       clobber ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz &&\
-      applywarp --in=${rawEpiDir}/${roi}_ms/cope1.nii \
-      --ref="$rawEpiDir"/${preprocfeat}/reg/standard.nii.gz \
+      applywarp --in=${roiOutDir}/${roi}_ms/cope1.nii \
+      --ref=${preprocfeat}/reg/standard.nii.gz \
       --out=${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz \
-      --warp="$rawEpiDir"/${preprocfeat}/reg/example_func2standard_warp.nii.gz \
+      --warp=${preprocfeat}/reg/example_func2standard_warp.nii.gz \
       --datatype=float
 
       # Mask out data with MNI mask
@@ -834,44 +834,44 @@ EOF
 
         # Creating new plots with fsl_tsplot
         # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
-        yMax=$(cat ${rawEpiDir}/${roi}_residvol_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
-        yMin=$(cat ${rawEpiDir}/${roi}_residvol_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
+        yMax=$(cat ${roiOutDir}/${roi}_residvol_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
+        yMin=$(cat ${roiOutDir}/${roi}_residvol_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
 
         # Log the "scrubbed TRs"
-        xNum=$(cat ${rawEpiDir}/${roi}_residvol_ts.txt | wc -l)
+        xNum=$(cat ${roiOutDir}/${roi}_residvol_ts.txt | wc -l)
         count=1
         while [ $count -le $xNum ]; do
-          tsPlotIn=$(cat ${rawEpiDir}/${roi}_residvol_ts.txt | head -${count} | tail -1)
+          tsPlotIn=$(cat ${roiOutDir}/${roi}_residvol_ts.txt | head -${count} | tail -1)
           delPlotCheck=$(cat ${rawEpiDir}/deleted_vols.txt | awk '{$1=$1}1' | grep -E '(^| )'${count}'( |$)')
           if [ "$delPlotCheck" == "" ]; then
             delPlot=$yMin
           else
             delPlot=$yMax
           fi
-          echo $delPlot >> ${rawEpiDir}/${roi}_censored_TRplot.txt
+          echo $delPlot >> ${roiOutDir}/${roi}_censored_TRplot.txt
         let count=count+1
         done
 
         # Plot of normal data showing scrubbed TRs
-        fsl_tsplot -i ${rawEpiDir}/${roi}_residvol_ts.txt,${rawEpiDir}/${roi}_censored_TRplot.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' -a ",Scrubbed_TR" --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$rawEpiDir"/${roi}.png
+        fsl_tsplot -i ${roiOutDir}/${roi}_residvol_ts.txt,${roiOutDir}/${roi}_censored_TRplot.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' -a ",Scrubbed_TR" --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$roiOutDir"/${roi}.png
 
         # Plot of "scrubbed" data
-        fsl_tsplot -i ${rawEpiDir}/${roi}_residvol_ms_ts.txt -t "$roi Time Series (Scrubbed)" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$rawEpiDir"/${roi}_ms.png
+        fsl_tsplot -i ${roiOutDir}/${roi}_residvol_ms_ts.txt -t "$roi Time Series (Scrubbed)" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$roiOutDir"/${roi}_ms.png
 
 
-        echo "<br><img src=\"$rawEpiDir/${roi}.png\" alt=\"${roi} seed\"><img src=\"$rawEpiDir/${roi}_ms.png\" alt=\"${roi}_ms seed\"><br>" >> "$rawEpiDir"/analysisResults.html
+        echo "<br><img src=\"$roiOutDir/${roi}.png\" alt=\"${roi} seed\"><img src=\"$roiOutDir/${roi}_ms.png\" alt=\"${roi}_ms seed\"><br>" >> "$rawEpiDir"/analysisResults.html
 
       else
         # No scrubbed TRs
 
         # Creating new plots with fsl_tsplot
         # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
-        yMax=$(cat ${rawEpiDir}/${roi}_residvol_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
-        yMin=$(cat ${rawEpiDir}/${roi}_residvol_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
+        yMax=$(cat ${roiOutDir}/${roi}_residvol_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
+        yMin=$(cat ${roiOutDir}/${roi}_residvol_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
 
-        fsl_tsplot -i ${rawEpiDir}/${roi}_residvol_ts.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$rawEpiDir"/${roi}.png
+        fsl_tsplot -i ${roiOutDir}/${roi}_residvol_ts.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$roiOutDir"/${roi}.png
 
-        echo "<br><img src=\"$rawEpiDir/${roi}.png\" alt=\"$roi seed\"><br>" >> "$rawEpiDir"/analysisResults.html
+        echo "<br><img src=\"$roiOutDir/${roi}.png\" alt=\"$roi seed\"><br>" >> "$rawEpiDir"/analysisResults.html
       fi
     fi
   done
@@ -880,7 +880,7 @@ fi
 
 
 echo "$0 Complete"
-echo "Please make sure that the ROI folders were created in the ${rawEpiDir}/ folder."
+echo "Please make sure that the ROI folders were created in the ${roiOutDir}/ folder."
 echo "If resultant warped seeds (to MNI) were too small, they were NOT processed.  Check ${rawEpiDir}/seedsTooSmall for exclusions."
 echo "If motionscrubbing was set to 1 or 2, make sure that motionscrubbed data was created."
 echo "OCTAVE/Matlab wouldn't give an error even if this step was not successfully done."

--- a/seedVoxelCorrelation.sh
+++ b/seedVoxelCorrelation.sh
@@ -506,53 +506,55 @@ done
 
 
 #### Seed Voxel Correlation (Setup) ############
-echo "...Seed Voxel Correlation Setup"
+if [ "${seedmapFlag}" -eq 1 ]; then
 
-# Dimensions of EPI data
-numXdim=$(fslinfo $epiData | grep ^dim1 | awk '{print $2}')
-numYdim=$(fslinfo $epiData | grep ^dim2 | awk '{print $2}')
-numZdim=$(fslinfo $epiData | grep ^dim3 | awk '{print $2}')
+  echo "...Seed Voxel Correlation Setup"
 
-cp "$indir"/seeds.txt "$indir"/seeds_orig.txt
-> "$indir"/seeds_ms.txt
-> "$indir"/seeds.txt
+  # Dimensions of EPI data
+  numXdim=$(fslinfo $epiData | grep ^dim1 | awk '{print $2}')
+  numYdim=$(fslinfo $epiData | grep ^dim2 | awk '{print $2}')
+  numZdim=$(fslinfo $epiData | grep ^dim3 | awk '{print $2}')
 
-# check if seeding results exist, re-populate seeds.txt with non existing seeds
-for roi in $(cat "$indir"/seeds_orig.txt); do
-	if [[ $motionscrubFlag == 1 ]] && [ ! -f "$indir"/$nuisancefeat/stats/${roi}_ms/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_ms_standard_zmap.nii.gz ]; then
-		echo $roi >> "$indir"/seeds_ms.txt
-	fi
-	if [[ $motionscrubFlag == 0 ]] && [ ! -f "$indir"/$nuisancefeat/stats/${roi}/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_standard_zmap.nii.gz ]; then
-		echo $roi >> "$indir"/seeds.txt
-	fi
-	if [[ $motionscrubFlag == 2 ]]; then
-		if [ ! -f "$indir"/$nuisancefeat/stats/${roi}/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_standard_zmap.nii.gz ]; then
-			echo $roi >> "$indir"/seeds.txt
-		fi
-		if [ ! -f "$indir"/$nuisancefeat/stats/${roi}_ms/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_ms_standard_zmap.nii.gz ]; then
-			echo $roi >> "$indir"/seeds_ms.txt
-		fi
-	fi
-done
+  cp "$indir"/seeds.txt "$indir"/seeds_orig.txt
+  > "$indir"/seeds_ms.txt
+  > "$indir"/seeds.txt
 
-
-# Perform the Correlation
-# Take into account $motionscrubFlag
-
-# Check into matlab about fixing motion-scrubbing (Power method)
+  # check if seeding results exist, re-populate seeds.txt with non existing seeds
+  for roi in $(cat "$indir"/seeds_orig.txt); do
+  	if [[ $motionscrubFlag == 1 ]] && [ ! -f "$indir"/$nuisancefeat/stats/${roi}_ms/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_ms_standard_zmap.nii.gz ]; then
+  		echo $roi >> "$indir"/seeds_ms.txt
+  	fi
+  	if [[ $motionscrubFlag == 0 ]] && [ ! -f "$indir"/$nuisancefeat/stats/${roi}/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_standard_zmap.nii.gz ]; then
+  		echo $roi >> "$indir"/seeds.txt
+  	fi
+  	if [[ $motionscrubFlag == 2 ]]; then
+  		if [ ! -f "$indir"/$nuisancefeat/stats/${roi}/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_standard_zmap.nii.gz ]; then
+  			echo $roi >> "$indir"/seeds.txt
+  		fi
+  		if [ ! -f "$indir"/$nuisancefeat/stats/${roi}_ms/cope1.nii ] && [ ! -f $seedcorrDir/${roi}_ms_standard_zmap.nii.gz ]; then
+  			echo $roi >> "$indir"/seeds_ms.txt
+  		fi
+  	fi
+  done
 
 
-if [[ $motionscrubFlag == 0 ]]; then
+  # Perform the Correlation
+  # Take into account $motionscrubFlag
 
-# If $motionscrubFlag == 0 (no motionscrub), res4dnormandscaled never gets unzipped
-if [ -e "$indir"/$nuisancefeat/stats/res4d_normandscaled.nii.gz ] && [ "$indir"/$nuisancefeat/stats/res4d_normandscaled.nii ]; then
-	rm "$indir"/$nuisancefeat/stats/res4d_normandscaled.nii
-	gunzip -f "$indir"/$nuisancefeat/stats/res4d_normandscaled.nii.gz
-fi
+  # Check into matlab about fixing motion-scrubbing (Power method)
 
 
-echo "...Creating Octave script"
-cat > $filename << EOF
+  if [[ $motionscrubFlag == 0 ]]; then
+
+  # If $motionscrubFlag == 0 (no motionscrub), res4dnormandscaled never gets unzipped
+  if [ -e "$indir"/$nuisancefeat/stats/res4d_normandscaled.nii.gz ] && [ "$indir"/$nuisancefeat/stats/res4d_normandscaled.nii ]; then
+  	rm "$indir"/$nuisancefeat/stats/res4d_normandscaled.nii
+  	gunzip -f "$indir"/$nuisancefeat/stats/res4d_normandscaled.nii.gz
+  fi
+
+
+  echo "...Creating Octave script"
+  cat > $filename << EOF
 % It is matlab script
 addpath('${scriptDir}')
 statsScripts=['${scriptDir}','/Octave/nifti'];
@@ -569,10 +571,10 @@ input='res4d_normandscaled.nii';
 firstlevelseeding_parallel('"$indir"',roiList,'$nuisancefeat',funcvoldim,input,motion_scrub,doFisherZ)
 quit
 EOF
-elif [[ $motionscrubFlag == 1 ]]; then
+  elif [[ $motionscrubFlag == 1 ]]; then
 
-echo "...Creating Octave script (motionscrubbed data)"
-cat > $filename2 << EOF
+  echo "...Creating Octave script (motionscrubbed data)"
+  cat > $filename2 << EOF
 % It is matlab script
 addpath('${scriptDir}')
 statsScripts=['${scriptDir}','/Octave/nifti'];
@@ -589,10 +591,10 @@ input='res4d_normandscaled_motionscrubbed.nii';
 firstlevelseeding_parallel('"$indir"',roiList,'$nuisancefeat',funcvoldim,input,motion_scrub,doFisherZ)
 quit
 EOF
-else
+  else
 
-echo "...Creating Octave script"
-cat > $filename << EOF
+  echo "...Creating Octave script"
+  cat > $filename << EOF
 % It is matlab script
 addpath('${scriptDir}')
 statsScripts=['${scriptDir}','/Octave/nifti'];
@@ -610,8 +612,8 @@ firstlevelseeding_parallel('"$indir"',roiList,'$nuisancefeat',funcvoldim,input,m
 quit
 EOF
 
-echo "...Creating Octave script (motionscrubbed data)"
-cat > ${filename2} << EOF
+  echo "...Creating Octave script (motionscrubbed data)"
+  cat > ${filename2} << EOF
 % It is matlab script
 addpath('${scriptDir}')
 statsScripts=['${scriptDir}','/Octave/nifti'];
@@ -628,358 +630,358 @@ input='res4d_normandscaled_motionscrubbed.nii';
 firstlevelseeding_parallel('"$indir"',roiList,'$nuisancefeat',funcvoldim,input,motion_scrub,doFisherZ)
 quit
 EOF
-fi
+  fi
 
 #################################
 
-if [ ! "$(head -n 1 "$indir"/seeds.txt 2> /dev/null)" = ""  ] || [ ! "$(head -n 1 "$indir"/seeds_ms.txt 2> /dev/null)" = ""  ]; then
-    #### Seed Voxel Correlation (Execution) ############
-    echo "...Correlating Seeds With Time Series Data"
+  if [ ! "$(head -n 1 "$indir"/seeds.txt 2> /dev/null)" = ""  ] || [ ! "$(head -n 1 "$indir"/seeds_ms.txt 2> /dev/null)" = ""  ]; then
+      #### Seed Voxel Correlation (Execution) ############
+      echo "...Correlating Seeds With Time Series Data"
 
-    # Run script using Matlab or Octave
-    # Check for $motionscrubFlag, run appropriate file(s)
-    haveMatlab=$(which matlab)
-    if [[ "$haveMatlab" == "" ]]; then
-  		if [[ $motionscrubFlag == 0 ]]; then
-  		    octave --no-window-system "$indir"/$filename
-  		elif [[ $motionscrubFlag == 1 ]]; then
-  		    octave --no-window-system "$indir"/$filename2
-  		else
-  		    octave --no-window-system "$indir"/$filename
-  		    octave --no-window-system "$indir"/$filename2
-  		fi
-	  else
-  		if [[ $motionscrubFlag == 0 ]]; then
-  		    matlab -nodisplay -r "run "$indir"/$filename"
-  		elif [[ $motionscrubFlag == 1 ]]; then
-  		    matlab -nodisplay -r "run "$indir"/$filename2"
-  		else
-  		    matlab -nodisplay -r "run "$indir"/$filename"
-  		    matlab -nodisplay -r "run "$indir"/$filename2"
-  		fi
-    fi
-else
-	echo "no seeds to correlate."
-fi
+      # Run script using Matlab or Octave
+      # Check for $motionscrubFlag, run appropriate file(s)
+      haveMatlab=$(which matlab)
+      if [[ "$haveMatlab" == "" ]]; then
+    		if [[ $motionscrubFlag == 0 ]]; then
+    		    octave --no-window-system "$indir"/$filename
+    		elif [[ $motionscrubFlag == 1 ]]; then
+    		    octave --no-window-system "$indir"/$filename2
+    		else
+    		    octave --no-window-system "$indir"/$filename
+    		    octave --no-window-system "$indir"/$filename2
+    		fi
+  	  else
+    		if [[ $motionscrubFlag == 0 ]]; then
+    		    matlab -nodisplay -r "run "$indir"/$filename"
+    		elif [[ $motionscrubFlag == 1 ]]; then
+    		    matlab -nodisplay -r "run "$indir"/$filename2"
+    		else
+    		    matlab -nodisplay -r "run "$indir"/$filename"
+    		    matlab -nodisplay -r "run "$indir"/$filename2"
+    		fi
+      fi
+  else
+  	echo "no seeds to correlate."
+  fi
 #################################
 
 
 #### Zstat Results (to T1/MNI) ############
 
 
-echo "...Creating zstat Results Directory"
+  echo "...Creating zstat Results Directory"
 
 
-# Copy over anatomical files to results directory
-# T1 (highres)
-cp "$indir"/${nuisancefeat}/reg/highres.nii.gz ${seedcorrDir}
+  # Copy over anatomical files to results directory
+  # T1 (highres)
+  cp "$indir"/${nuisancefeat}/reg/highres.nii.gz ${seedcorrDir}
 
-# T1toMNI (highres2standard)
-cp "$indir"/${nuisancefeat}/reg/highres2standard.nii.gz ${seedcorrDir}
+  # T1toMNI (highres2standard)
+  cp "$indir"/${nuisancefeat}/reg/highres2standard.nii.gz ${seedcorrDir}
 
-# MNI (standard)
-cp "$indir"/${nuisancefeat}/reg/standard.nii.gz ${seedcorrDir}
+  # MNI (standard)
+  cp "$indir"/${nuisancefeat}/reg/standard.nii.gz ${seedcorrDir}
 
 
-# HTML setup
-echo "<hr><h2>Seed Time Series</h2>" >> "$indir"/analysisResults.html
+  # HTML setup
+  echo "<hr><h2>Seed Time Series</h2>" >> "$indir"/analysisResults.html
 
-for roi in $(cat "$indir"/seeds_orig.txt); do
-  echo "...Mapping Correlation For $roi To Subject T1, MNI"
-  # Adjust for motion scrubbing
-  if [[ $motionscrubFlag == 0 ]]; then
-    # No motionscrubbing
-    if [ -e ${roi}.png ]; then
-      rm ${roi}.png
-    fi
+  for roi in $(cat "$indir"/seeds_orig.txt); do
+    echo "...Mapping Correlation For $roi To Subject T1, MNI"
+    # Adjust for motion scrubbing
+    if [[ $motionscrubFlag == 0 ]]; then
+      # No motionscrubbing
+      if [ -e ${roi}.png ]; then
+        rm ${roi}.png
+      fi
 
-    # Check for FieldMap registration correction
-    if [[ $fieldMapFlag == 1 ]]; then
-      # Nonlinear warp from EPI to T1
-      clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
+      # Check for FieldMap registration correction
+      if [[ $fieldMapFlag == 1 ]]; then
+        # Nonlinear warp from EPI to T1
+        clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
+        applywarp --in="$indir"/${nuisancefeat}/stats/${roi}/cope1.nii \
+        --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
+        --out=${seedcorrDir}/${roi}_highres_zmap.nii.gz \
+        --warp="$indir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
+        --datatype=float
+      else
+        # Affine Transform from EPI to T1
+        clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
+        flirt -in "$indir"/${nuisancefeat}/stats/${roi}/cope1.nii \
+        -ref "$indir"/${nuisancefeat}/reg/highres.nii.gz \
+        -out ${seedcorrDir}/${roi}_highres_zmap.nii.gz \
+        -applyxfm -init "$indir"/${nuisancefeat}/reg/example_func2highres.mat \
+        -datatype float
+      fi
+
+      # Mask out data with T1 mask (create temporary binary of skull-stripped T1)
+      fslmaths "$indir"/${nuisancefeat}/reg/highres.nii.gz -bin "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
+      fslmaths ${seedcorrDir}/${roi}_highres_zmap.nii.gz -mas "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_highres_zmap_masked.nii.gz
+      rm "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz
+
+      # Nonlinear warp from EPI to MNI
+      clobber ${seedcorrDir}/${roi}_standard_zmap.nii.gz &&\
       applywarp --in="$indir"/${nuisancefeat}/stats/${roi}/cope1.nii \
-      --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
-      --out=${seedcorrDir}/${roi}_highres_zmap.nii.gz \
-      --warp="$indir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
+      --ref="$indir"/${nuisancefeat}/reg/standard.nii.gz \
+      --out=${seedcorrDir}/${roi}_standard_zmap.nii.gz \
+      --warp="$indir"/${nuisancefeat}/reg/example_func2standard_warp.nii.gz \
       --datatype=float
-    else
-      # Affine Transform from EPI to T1
-      clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
-      flirt -in "$indir"/${nuisancefeat}/stats/${roi}/cope1.nii \
-      -ref "$indir"/${nuisancefeat}/reg/highres.nii.gz \
-      -out ${seedcorrDir}/${roi}_highres_zmap.nii.gz \
-      -applyxfm -init "$indir"/${nuisancefeat}/reg/example_func2highres.mat \
-      -datatype float
-    fi
 
-    # Mask out data with T1 mask (create temporary binary of skull-stripped T1)
-    fslmaths "$indir"/${nuisancefeat}/reg/highres.nii.gz -bin "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
-    fslmaths ${seedcorrDir}/${roi}_highres_zmap.nii.gz -mas "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_highres_zmap_masked.nii.gz
-    rm "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz
+      # Mask out data with MNI mask
+      fslmaths ${seedcorrDir}/${roi}_standard_zmap.nii.gz -mas $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz ${seedcorrDir}/${roi}_standard_zmap_masked.nii.gz
 
-    # Nonlinear warp from EPI to MNI
-    clobber ${seedcorrDir}/${roi}_standard_zmap.nii.gz &&\
-    applywarp --in="$indir"/${nuisancefeat}/stats/${roi}/cope1.nii \
-    --ref="$indir"/${nuisancefeat}/reg/standard.nii.gz \
-    --out=${seedcorrDir}/${roi}_standard_zmap.nii.gz \
-    --warp="$indir"/${nuisancefeat}/reg/example_func2standard_warp.nii.gz \
-    --datatype=float
-
-    # Mask out data with MNI mask
-    fslmaths ${seedcorrDir}/${roi}_standard_zmap.nii.gz -mas $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz ${seedcorrDir}/${roi}_standard_zmap_masked.nii.gz
-
-    # Warp seed from MNI to T1
-    clobber ${seedcorrDir}/${roi}_highres.nii.gz &&\
-    applywarp --in=${seedcorrDir}/${roi}_standard.nii.gz \
-    --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
-    --out=${seedcorrDir}/${roi}_highres.nii.gz \
-    --warp="$indir"/${nuisancefeat}/reg/standard2highres_warp.nii.gz \
-    --interp=nn
-
-    # Creating new plots with fsl_tsplot
-    # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
-    yMax=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
-    yMin=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
-
-    clobber "$indir"/${roi}.png &&\
-    fsl_tsplot -i "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$indir"/${roi}.png
-
-    echo "<br><img src=\""$indir"/${roi}.png\" alt=\"$roi seed\"><br>" >> "$indir"/analysisResults.html
-
-  elif [[ $motionscrubFlag == 1 ]]; then
-    # Only motionscrubbed data
-    if [ -e ${roi}_ms.png ]; then
-      rm ${roi}_ms.png
-    fi
-
-    # Check for FieldMap registration correction
-    if [[ $fieldMapFlag == 1 ]]; then
-      # Nonlinear warp from EPI to T1
-      clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
-      applywarp --in="$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
+      # Warp seed from MNI to T1
+      clobber ${seedcorrDir}/${roi}_highres.nii.gz &&\
+      applywarp --in=${seedcorrDir}/${roi}_standard.nii.gz \
       --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
-      --out=${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
-      --warp="$indir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
-      --datatype=float
-    else
-      # Affine Transform from EPI to T1
-      clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
-      flirt -in "$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
-      -ref "$indir"/${nuisancefeat}/reg/highres.nii.gz \
-      -out ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
-      -applyxfm -init "$indir"/${nuisancefeat}/reg/example_func2highres.mat \
-      -datatype float
-    fi
-
-    # Mask out data with T1 mask (create temporary binary of skull-stripped T1)
-    fslmaths "$indir"/${nuisancefeat}/reg/highres.nii.gz -bin "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
-    fslmaths ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz -mas "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_ms_highres_zmap_masked.nii.gz
-    rm "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz
-
-    # Nonlinear warp from EPI to MNI
-    clobber ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz &&\
-    applywarp --in="$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
-    --ref="$indir"/${nuisancefeat}/reg/standard.nii.gz \
-    --out=${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz \
-    --warp="$indir"/${nuisancefeat}/reg/example_func2standard_warp.nii.gz \
-    --datatype=float
-
-    # Mask out data with MNI mask
-    fslmaths ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz -mas $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz ${seedcorrDir}/${roi}_ms_standard_zmap_masked.nii.gz
-
-    # Warp seed from MNI to T1
-    clobber ${seedcorrDir}/${roi}_highres.nii.gz &&\
-    applywarp --in=${seedcorrDir}/${roi}_standard.nii.gz \
-    --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
-    --out=${seedcorrDir}/${roi}_highres.nii.gz \
-    --warp="$indir"/${nuisancefeat}/reg/standard2highres_warp.nii.gz \
-    --interp=nn
-
-
-    # Look for the presence of deleted volumes.  ONLY create "spike" (ms) images if found, otherwise default to non-motionscrubbed images
-    scrubDataCheck=$(cat "$indir"/$nuisancefeat/stats/deleted_vols.txt | head -1)
-
-    if [[ $scrubDataCheck != "" ]]; then
-      # Presence of scrubbed volumes
-
-      # Creating new plots with fsl_tsplot
-      # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
-      yMax=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
-      yMin=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
-
-      # Log the "scrubbed TRs"
-      xNum=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | wc -l)
-      count=1
-      while [ $count -le $xNum ]; do
-        tsPlotIn=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | head -${count} | tail -1)
-        delPlotCheck=$(cat "$indir"/${nuisancefeat}/stats/deleted_vols.txt | awk '{$1=$1}1' | grep -E '(^| )'${count}'( |$)')
-        if [ "$delPlotCheck" == "" ]; then
-          delPlot=$yMin
-        else
-          delPlot=$yMax
-        fi
-        echo $delPlot >> "$indir"/${nuisancefeat}/stats/${roi}_censored_TRplot.txt
-      let count=count+1
-      done
-
-      #Plot of "scrubbed" data
-      clobber "$indir"/${roi}_ms.png &&\
-      fsl_tsplot -i "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt -t "$roi Time Series (Scrubbed)" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$indir"/${roi}_ms.png
-
-      echo "<br><img src=\""$indir"/${roi}.png\" alt=\"${roi} seed\"><img src=\""$indir"/${roi}_ms.png\" alt=\"${roi}_ms seed\"><br>" >> "$indir"/analysisResults.html
-
-    else
-      # Absence of scrubbed volumes
-
-      # Creating new plots with fsl_tsplot
-      # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
-      yMax=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
-      yMin=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
-
-      fsl_tsplot -i "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$indir"/${roi}.png
-
-      echo "<br><img src=\""$indir"/${roi}.png\" alt=\"$roi seed\"><br>" >> "$indir"/analysisResults.html
-    fi
-
-  else
-    # Non-motionscrubbed data
-    if [ -e ${roi}.png ]; then
-      rm ${roi}.png
-    fi
-    if [ -e ${roi}_ms.png ]; then
-      rm ${roi}_ms.png
-    fi
-
-    # Check for FieldMap registration correction
-    if [[ $fieldMapFlag == 1 ]]; then
-      # Nonlinear warp from EPI to T1
-      clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
-      applywarp --in="$indir"/${nuisancefeat}/stats/${roi}/cope1.nii \
-      --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
-      --out=${seedcorrDir}/${roi}_highres_zmap.nii.gz \
-      --warp="$indir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
-      --datatype=float
-    else
-      # Affine Transform from EPI to T1
-      clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
-      flirt -in "$indir"/${nuisancefeat}/stats/${roi}/cope1.nii \
-      -ref "$indir"/${nuisancefeat}/reg/highres.nii.gz \
-      -out ${seedcorrDir}/${roi}_highres_zmap.nii.gz \
-      -applyxfm -init "$indir"/${nuisancefeat}/reg/example_func2highres.mat \
-      -datatype float
-    fi
-
-    # Mask out data with T1 mask (create temporary binary of skull-stripped T1)
-    fslmaths "$indir"/${nuisancefeat}/reg/highres.nii.gz -bin "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
-    fslmaths ${seedcorrDir}/${roi}_highres_zmap.nii.gz -mas "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_highres_zmap_masked.nii.gz
-
-    # Nonlinear warp from EPI to MNI
-    clobber ${seedcorrDir}/${roi}_standard_zmap.nii.gz &&\
-    applywarp --in="$indir"/${nuisancefeat}/stats/${roi}/cope1.nii \
-    --ref="$indir"/${nuisancefeat}/reg/standard.nii.gz \
-    --out=${seedcorrDir}/${roi}_standard_zmap.nii.gz \
-    --warp="$indir"/${nuisancefeat}/reg/example_func2standard_warp.nii.gz \
-    --datatype=float
-
-    # Mask out data with MNI mask
-    fslmaths ${seedcorrDir}/${roi}_standard_zmap.nii.gz -mas $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz ${seedcorrDir}/${roi}_standard_zmap_masked.nii.gz
-
-    # Warp seed from MNI to T1
-    clobber ${seedcorrDir}/${roi}_highres.nii.gz &&\
-    applywarp --in=${seedcorrDir}/${roi}_standard.nii.gz \
-    --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
-    --out=${seedcorrDir}/${roi}_highres.nii.gz \
-    --warp="$indir"/${nuisancefeat}/reg/standard2highres_warp.nii.gz \
-    --interp=nn
-
-
-    # Motionscrubbed data
-    # Check for FieldMap registration correction
-    if [[ $fieldMapFlag == 1 ]]; then
-      # Nonlinear warp from EPI to T1
-      clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
-      applywarp --in="$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
-      --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
-      --out=${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
-      --warp="$indir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
-      --datatype=float
-    else
-      # Affine Transform from EPI to T1
-      clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
-      flirt -in "$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
-      -ref "$indir"/${nuisancefeat}/reg/highres.nii.gz \
-      -out ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
-      -applyxfm -init "$indir"/${nuisancefeat}/reg/example_func2highres.mat \
-      -datatype float
-    fi
-
-    # Mask out data with T1 mask (remove temporary binary of skull-stripped T1)
-    fslmaths "$indir"/${nuisancefeat}/reg/highres.nii.gz -bin "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
-    fslmaths ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz -mas "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_ms_highres_zmap_masked.nii.gz
-    rm "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz
-
-    # Nonlinear warp from EPI to MNI
-    clobber ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz &&\
-    applywarp --in="$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
-    --ref="$indir"/${nuisancefeat}/reg/standard.nii.gz \
-    --out=${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz \
-    --warp="$indir"/${nuisancefeat}/reg/example_func2standard_warp.nii.gz \
-    --datatype=float
-
-    # Mask out data with MNI mask
-    fslmaths ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz -mas $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz ${seedcorrDir}/${roi}_ms_standard_zmap_masked.nii.gz
-
-
-    # Look for the presence of deleted volumes.  ONLY create "spike" (ms) images if found, otherwise default to non-motionscrubbed images
-    scrubDataCheck=$(cat "$indir"/$nuisancefeat/stats/deleted_vols.txt | head -1)
-
-    if [[ $scrubDataCheck != "" ]]; then
-      #Presence of scrubbed volumes
+      --out=${seedcorrDir}/${roi}_highres.nii.gz \
+      --warp="$indir"/${nuisancefeat}/reg/standard2highres_warp.nii.gz \
+      --interp=nn
 
       # Creating new plots with fsl_tsplot
       # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
       yMax=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
       yMin=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
 
-      # Log the "scrubbed TRs"
-      xNum=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | wc -l)
-      count=1
-      while [ $count -le $xNum ]; do
-        tsPlotIn=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | head -${count} | tail -1)
-        delPlotCheck=$(cat "$indir"/${nuisancefeat}/stats/deleted_vols.txt | awk '{$1=$1}1' | grep -E '(^| )'${count}'( |$)')
-        if [ "$delPlotCheck" == "" ]; then
-          delPlot=$yMin
-        else
-          delPlot=$yMax
-        fi
-        echo $delPlot >> "$indir"/${nuisancefeat}/stats/${roi}_censored_TRplot.txt
-      let count=count+1
-      done
-
-      # Plot of normal data showing scrubbed TRs
-      fsl_tsplot -i "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt,"$indir"/${nuisancefeat}/stats/${roi}_censored_TRplot.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' -a ",Scrubbed_TR" --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$indir"/${roi}.png
-
-      # Plot of "scrubbed" data
-      fsl_tsplot -i "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt -t "$roi Time Series (Scrubbed)" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$indir"/${roi}_ms.png
-
-
-      echo "<br><img src=\""$indir"/${roi}.png\" alt=\"${roi} seed\"><img src=\""$indir"/${roi}_ms.png\" alt=\"${roi}_ms seed\"><br>" >> "$indir"/analysisResults.html
-
-    else
-      # No scrubbed TRs
-
-      # Creating new plots with fsl_tsplot
-      # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
-      yMax=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
-      yMin=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
-
+      clobber "$indir"/${roi}.png &&\
       fsl_tsplot -i "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$indir"/${roi}.png
 
       echo "<br><img src=\""$indir"/${roi}.png\" alt=\"$roi seed\"><br>" >> "$indir"/analysisResults.html
-    fi
-  fi
-done
 
+    elif [[ $motionscrubFlag == 1 ]]; then
+      # Only motionscrubbed data
+      if [ -e ${roi}_ms.png ]; then
+        rm ${roi}_ms.png
+      fi
+
+      # Check for FieldMap registration correction
+      if [[ $fieldMapFlag == 1 ]]; then
+        # Nonlinear warp from EPI to T1
+        clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
+        applywarp --in="$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
+        --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
+        --out=${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
+        --warp="$indir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
+        --datatype=float
+      else
+        # Affine Transform from EPI to T1
+        clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
+        flirt -in "$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
+        -ref "$indir"/${nuisancefeat}/reg/highres.nii.gz \
+        -out ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
+        -applyxfm -init "$indir"/${nuisancefeat}/reg/example_func2highres.mat \
+        -datatype float
+      fi
+
+      # Mask out data with T1 mask (create temporary binary of skull-stripped T1)
+      fslmaths "$indir"/${nuisancefeat}/reg/highres.nii.gz -bin "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
+      fslmaths ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz -mas "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_ms_highres_zmap_masked.nii.gz
+      rm "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz
+
+      # Nonlinear warp from EPI to MNI
+      clobber ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz &&\
+      applywarp --in="$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
+      --ref="$indir"/${nuisancefeat}/reg/standard.nii.gz \
+      --out=${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz \
+      --warp="$indir"/${nuisancefeat}/reg/example_func2standard_warp.nii.gz \
+      --datatype=float
+
+      # Mask out data with MNI mask
+      fslmaths ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz -mas $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz ${seedcorrDir}/${roi}_ms_standard_zmap_masked.nii.gz
+
+      # Warp seed from MNI to T1
+      clobber ${seedcorrDir}/${roi}_highres.nii.gz &&\
+      applywarp --in=${seedcorrDir}/${roi}_standard.nii.gz \
+      --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
+      --out=${seedcorrDir}/${roi}_highres.nii.gz \
+      --warp="$indir"/${nuisancefeat}/reg/standard2highres_warp.nii.gz \
+      --interp=nn
+
+
+      # Look for the presence of deleted volumes.  ONLY create "spike" (ms) images if found, otherwise default to non-motionscrubbed images
+      scrubDataCheck=$(cat "$indir"/$nuisancefeat/stats/deleted_vols.txt | head -1)
+
+      if [[ $scrubDataCheck != "" ]]; then
+        # Presence of scrubbed volumes
+
+        # Creating new plots with fsl_tsplot
+        # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
+        yMax=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
+        yMin=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
+
+        # Log the "scrubbed TRs"
+        xNum=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | wc -l)
+        count=1
+        while [ $count -le $xNum ]; do
+          tsPlotIn=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | head -${count} | tail -1)
+          delPlotCheck=$(cat "$indir"/${nuisancefeat}/stats/deleted_vols.txt | awk '{$1=$1}1' | grep -E '(^| )'${count}'( |$)')
+          if [ "$delPlotCheck" == "" ]; then
+            delPlot=$yMin
+          else
+            delPlot=$yMax
+          fi
+          echo $delPlot >> "$indir"/${nuisancefeat}/stats/${roi}_censored_TRplot.txt
+        let count=count+1
+        done
+
+        #Plot of "scrubbed" data
+        clobber "$indir"/${roi}_ms.png &&\
+        fsl_tsplot -i "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt -t "$roi Time Series (Scrubbed)" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$indir"/${roi}_ms.png
+
+        echo "<br><img src=\""$indir"/${roi}.png\" alt=\"${roi} seed\"><img src=\""$indir"/${roi}_ms.png\" alt=\"${roi}_ms seed\"><br>" >> "$indir"/analysisResults.html
+
+      else
+        # Absence of scrubbed volumes
+
+        # Creating new plots with fsl_tsplot
+        # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
+        yMax=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
+        yMin=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
+
+        fsl_tsplot -i "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$indir"/${roi}.png
+
+        echo "<br><img src=\""$indir"/${roi}.png\" alt=\"$roi seed\"><br>" >> "$indir"/analysisResults.html
+      fi
+
+    else
+      # Non-motionscrubbed data
+      if [ -e ${roi}.png ]; then
+        rm ${roi}.png
+      fi
+      if [ -e ${roi}_ms.png ]; then
+        rm ${roi}_ms.png
+      fi
+
+      # Check for FieldMap registration correction
+      if [[ $fieldMapFlag == 1 ]]; then
+        # Nonlinear warp from EPI to T1
+        clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
+        applywarp --in="$indir"/${nuisancefeat}/stats/${roi}/cope1.nii \
+        --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
+        --out=${seedcorrDir}/${roi}_highres_zmap.nii.gz \
+        --warp="$indir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
+        --datatype=float
+      else
+        # Affine Transform from EPI to T1
+        clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
+        flirt -in "$indir"/${nuisancefeat}/stats/${roi}/cope1.nii \
+        -ref "$indir"/${nuisancefeat}/reg/highres.nii.gz \
+        -out ${seedcorrDir}/${roi}_highres_zmap.nii.gz \
+        -applyxfm -init "$indir"/${nuisancefeat}/reg/example_func2highres.mat \
+        -datatype float
+      fi
+
+      # Mask out data with T1 mask (create temporary binary of skull-stripped T1)
+      fslmaths "$indir"/${nuisancefeat}/reg/highres.nii.gz -bin "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
+      fslmaths ${seedcorrDir}/${roi}_highres_zmap.nii.gz -mas "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_highres_zmap_masked.nii.gz
+
+      # Nonlinear warp from EPI to MNI
+      clobber ${seedcorrDir}/${roi}_standard_zmap.nii.gz &&\
+      applywarp --in="$indir"/${nuisancefeat}/stats/${roi}/cope1.nii \
+      --ref="$indir"/${nuisancefeat}/reg/standard.nii.gz \
+      --out=${seedcorrDir}/${roi}_standard_zmap.nii.gz \
+      --warp="$indir"/${nuisancefeat}/reg/example_func2standard_warp.nii.gz \
+      --datatype=float
+
+      # Mask out data with MNI mask
+      fslmaths ${seedcorrDir}/${roi}_standard_zmap.nii.gz -mas $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz ${seedcorrDir}/${roi}_standard_zmap_masked.nii.gz
+
+      # Warp seed from MNI to T1
+      clobber ${seedcorrDir}/${roi}_highres.nii.gz &&\
+      applywarp --in=${seedcorrDir}/${roi}_standard.nii.gz \
+      --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
+      --out=${seedcorrDir}/${roi}_highres.nii.gz \
+      --warp="$indir"/${nuisancefeat}/reg/standard2highres_warp.nii.gz \
+      --interp=nn
+
+
+      # Motionscrubbed data
+      # Check for FieldMap registration correction
+      if [[ $fieldMapFlag == 1 ]]; then
+        # Nonlinear warp from EPI to T1
+        clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
+        applywarp --in="$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
+        --ref="$indir"/${nuisancefeat}/reg/highres.nii.gz \
+        --out=${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
+        --warp="$indir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
+        --datatype=float
+      else
+        # Affine Transform from EPI to T1
+        clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
+        flirt -in "$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
+        -ref "$indir"/${nuisancefeat}/reg/highres.nii.gz \
+        -out ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
+        -applyxfm -init "$indir"/${nuisancefeat}/reg/example_func2highres.mat \
+        -datatype float
+      fi
+
+      # Mask out data with T1 mask (remove temporary binary of skull-stripped T1)
+      fslmaths "$indir"/${nuisancefeat}/reg/highres.nii.gz -bin "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
+      fslmaths ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz -mas "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_ms_highres_zmap_masked.nii.gz
+      rm "$indir"/${nuisancefeat}/reg/highres_mask.nii.gz
+
+      # Nonlinear warp from EPI to MNI
+      clobber ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz &&\
+      applywarp --in="$indir"/${nuisancefeat}/stats/${roi}_ms/cope1.nii \
+      --ref="$indir"/${nuisancefeat}/reg/standard.nii.gz \
+      --out=${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz \
+      --warp="$indir"/${nuisancefeat}/reg/example_func2standard_warp.nii.gz \
+      --datatype=float
+
+      # Mask out data with MNI mask
+      fslmaths ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz -mas $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz ${seedcorrDir}/${roi}_ms_standard_zmap_masked.nii.gz
+
+
+      # Look for the presence of deleted volumes.  ONLY create "spike" (ms) images if found, otherwise default to non-motionscrubbed images
+      scrubDataCheck=$(cat "$indir"/$nuisancefeat/stats/deleted_vols.txt | head -1)
+
+      if [[ $scrubDataCheck != "" ]]; then
+        #Presence of scrubbed volumes
+
+        # Creating new plots with fsl_tsplot
+        # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
+        yMax=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
+        yMin=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
+
+        # Log the "scrubbed TRs"
+        xNum=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | wc -l)
+        count=1
+        while [ $count -le $xNum ]; do
+          tsPlotIn=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | head -${count} | tail -1)
+          delPlotCheck=$(cat "$indir"/${nuisancefeat}/stats/deleted_vols.txt | awk '{$1=$1}1' | grep -E '(^| )'${count}'( |$)')
+          if [ "$delPlotCheck" == "" ]; then
+            delPlot=$yMin
+          else
+            delPlot=$yMax
+          fi
+          echo $delPlot >> "$indir"/${nuisancefeat}/stats/${roi}_censored_TRplot.txt
+        let count=count+1
+        done
+
+        # Plot of normal data showing scrubbed TRs
+        fsl_tsplot -i "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt,"$indir"/${nuisancefeat}/stats/${roi}_censored_TRplot.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' -a ",Scrubbed_TR" --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$indir"/${roi}.png
+
+        # Plot of "scrubbed" data
+        fsl_tsplot -i "$indir"/${nuisancefeat}/stats/${roi}_residvol_ms_ts.txt -t "$roi Time Series (Scrubbed)" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$indir"/${roi}_ms.png
+
+
+        echo "<br><img src=\""$indir"/${roi}.png\" alt=\"${roi} seed\"><img src=\""$indir"/${roi}_ms.png\" alt=\"${roi}_ms seed\"><br>" >> "$indir"/analysisResults.html
+
+      else
+        # No scrubbed TRs
+
+        # Creating new plots with fsl_tsplot
+        # ~2.2% plotting difference between actual Ymin and Ymax values (higher and lower), with fsl_tsplot
+        yMax=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | sort -r | tail -1 | awk '{print ($1+($1*0.0022))}')
+        yMin=$(cat "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt | tail -1 | awk '{print ($1-($1*0.0022))}')
+
+        fsl_tsplot -i "$indir"/${nuisancefeat}/stats/${roi}_residvol_ts.txt -t "$roi Time Series" -u 1 --start=1 -x 'Time Points (TR)' --ymin=$yMin --ymax=$yMax -w 800 -h 300 -o "$indir"/${roi}.png
+
+        echo "<br><img src=\""$indir"/${roi}.png\" alt=\"$roi seed\"><br>" >> "$indir"/analysisResults.html
+      fi
+    fi
+  done
+fi
 #################################
 
 

--- a/seedVoxelCorrelation.sh
+++ b/seedVoxelCorrelation.sh
@@ -20,12 +20,12 @@ function Usage {
   echo "Usage: seedVoxelCorrelation.sh --epi=restingStateImage --roiList=roiList.txt --motionscrub"
   echo " where"
   echo "   --epi resting state image"
-  echo "        *Top-level RestingState.nii.gz image"
+  echo "        *this is the residual 4d image after nuisance regression"
   echo "   --motionscrub use motionscrubbed and non-motionscrubbed EPI (parallel output)"
   echo "   --roiList Data file with seed list, one seed per line"
   echo "        **Use ONLY one option, -r or -R, NOT both"
-  echo "   --compcor flag if CompCor reg was performed"
-  echo "   --seedmaps print seedmaps (default is off)"
+  echo "   --compcor Flag if CompCor reg was performed"
+  echo "   --seedmaps Flag to output seedmaps (default is off)"
   echo ""
   exit 1
 }

--- a/seedVoxelCorrelation.sh
+++ b/seedVoxelCorrelation.sh
@@ -492,9 +492,9 @@ if [ "${seedmapFlag}" -eq 1 ]; then
   # set directory for seed maps
   # strong assumption that only classic and compcor
   if [ ${compcorFlag} -eq 1 ]; then
-    seedcorrDir=${roiOutDir}/seedCorrelation_compcor
+    seedcorrDir=${rawEpiDir}/seedCorrelation_compcor
   else
-    seedcorrDir=${roiOutDir}/seedCorrelation
+    seedcorrDir=${rawEpiDir}/seedCorrelation
   fi
 
   mkdir -p ${seedcorrDir}
@@ -548,7 +548,7 @@ if [ "${seedmapFlag}" -eq 1 ]; then
 addpath('${scriptDir}')
 statsScripts=['${scriptDir}','/Octave/nifti'];
 addpath(statsScripts)
-fid=fopen('"$rawEpiDir"/seeds.txt');
+fid=fopen('$rawEpiDir/seeds.txt');
 roiList=textscan(fid,'%s');
 fclose(fid);
 
@@ -568,7 +568,7 @@ EOF
 addpath('${scriptDir}')
 statsScripts=['${scriptDir}','/Octave/nifti'];
 addpath(statsScripts)
-fid=fopen('"$rawEpiDir"/seeds_ms.txt');
+fid=fopen('$rawEpiDir/seeds_ms.txt');
 roiList=textscan(fid,'%s');
 fclose(fid);
 
@@ -588,7 +588,7 @@ EOF
 addpath('${scriptDir}')
 statsScripts=['${scriptDir}','/Octave/nifti'];
 addpath(statsScripts)
-fid=fopen('"$rawEpiDir"/seeds.txt');
+fid=fopen('$rawEpiDir/seeds.txt');
 roiList=textscan(fid,'%s');
 fclose(fid);
 
@@ -607,7 +607,7 @@ EOF
 addpath('${scriptDir}')
 statsScripts=['${scriptDir}','/Octave/nifti'];
 addpath(statsScripts)
-fid=fopen('"$rawEpiDir"/seeds_ms.txt');
+fid=fopen('$rawEpiDir/seeds_ms.txt');
 roiList=textscan(fid,'%s');
 fclose(fid);
 

--- a/seedVoxelCorrelation.sh
+++ b/seedVoxelCorrelation.sh
@@ -17,18 +17,15 @@ VossLabMount="$(mount | grep vosslabhpc | awk '{print $3}')"
 
 
 function Usage {
-  echo "Usage: seedVoxelCorrelation.sh --epi=restingStateImage --roiList=roiList.txt --motionscrub --fmap"
+  echo "Usage: seedVoxelCorrelation.sh --epi=restingStateImage --roiList=roiList.txt --motionscrub"
   echo " where"
   echo "   --epi resting state image"
   echo "        *Top-level RestingState.nii.gz image"
   echo "   --motionscrub use motionscrubbed and non-motionscrubbed EPI (parallel output)"
   echo "   --roiList Data file with seed list, one seed per line"
   echo "        **Use ONLY one option, -r or -R, NOT both"
-  echo "   --compcor"
+  echo "   --compcor flag if CompCor reg was performed"
   echo "   --seedmaps print seedmaps (default is off)"
-  echo "   --fmap (fieldMap registration correction)"
-  echo "        *Only set this flag if FieldMap correction was used during qualityCheck"
-  echo "        **This affects only the EPI to T1 QC images"
   echo ""
   exit 1
 }
@@ -140,9 +137,6 @@ while [ $# -ge 1 ] ; do
       motionscrubFlag=1;
       export motionscrubFlag;
       shift;;
-    -f)
-      fieldMapFlag=1;
-      shift;;
     -c)
       clob=true;
       export clob;
@@ -163,9 +157,6 @@ if [[ $motionscrubFlag == "" ]]; then
 motionscrubFlag=0
 fi
 
-if [[ $fieldMapFlag == "" ]]; then
-fieldMapFlag=0
-fi
 
 # If new seeds are added, echo them out to the rsParams file (only if they don't already exist in the file)
 # Making a *strong* assumption that any ROI lists added after initial processing won't reuse the first ROI (e.g. pccrsp)
@@ -207,9 +198,6 @@ if [[ $roiInd == 1 ]]; then
   echo "$seeds" >> $logDir/rsParams_log
 else
   echo "-R $roiInFile" >> $logDir/rsParams_log
-fi
-if [[ $fieldMapFlag == 1 ]]; then
-  echo "-f" >> $logDir/rsParams_log
 fi
 echo "$(date)" >> $logDir/rsParams_log
 echo "" >> $logDir/rsParams_log

--- a/seedVoxelCorrelation.sh
+++ b/seedVoxelCorrelation.sh
@@ -574,7 +574,7 @@ doFisherZ=1;
 motion_scrub=1;
 input='${epiData/.nii.gz/_ms.nii}';
 
-firstlevelseeding_parallel('$rawEpiDir',roiList,'$roiOutDir',funcvoldim,input,motion_scrub,doFisherZ)
+firstlevelseeding_parallel(roiList,'$roiOutDir',funcvoldim,input,motion_scrub,doFisherZ)
 quit
 EOF
   else
@@ -594,7 +594,7 @@ doFisherZ=1;
 motion_scrub=0;
 input='${epiData/.nii.gz/.nii}';
 
-firstlevelseeding_parallel('$rawEpiDir',roiList,'$roiOutDir',funcvoldim,input,motion_scrub,doFisherZ)
+firstlevelseeding_parallel(roiList,'$roiOutDir',funcvoldim,input,motion_scrub,doFisherZ)
 quit
 EOF
 
@@ -613,7 +613,7 @@ doFisherZ=1;
 motion_scrub=1;
 input='${epiData/.nii.gz/_ms.nii}';
 
-firstlevelseeding_parallel('$rawEpiDir',roiList,'$roiOutDir',funcvoldim,input,motion_scrub,doFisherZ)
+firstlevelseeding_parallel(roiList,'$roiOutDir',funcvoldim,input,motion_scrub,doFisherZ)
 quit
 EOF
   fi

--- a/seedVoxelCorrelation.sh
+++ b/seedVoxelCorrelation.sh
@@ -17,7 +17,7 @@ VossLabMount="$(mount | grep vosslabhpc | awk '{print $3}')"
 
 
 function Usage {
-  echo "Usage: seedVoxelCorrelation.sh -E restingStateImage -r roi -m motionscrubFlag -n -f"
+  echo "Usage: seedVoxelCorrelation.sh --epi=restingStateImage --roiList=roiList.txt --motionscrub --fmap"
   echo " where"
   echo "   --epi resting state image"
   echo "        *Top-level RestingState.nii.gz image"
@@ -26,7 +26,7 @@ function Usage {
   echo "        **Use ONLY one option, -r or -R, NOT both"
   echo "   --compcor"
   echo "   --seedmaps print seedmaps (default is off)"
-  echo "   -f (fieldMap registration correction)"
+  echo "   --fmap (fieldMap registration correction)"
   echo "        *Only set this flag if FieldMap correction was used during qualityCheck"
   echo "        **This affects only the EPI to T1 QC images"
   echo ""

--- a/seedVoxelCorrelation.sh
+++ b/seedVoxelCorrelation.sh
@@ -5,7 +5,7 @@
 #     1. Push Seed masks from MNI to EPI space
 #     2. Calculate Time-series for each Seed of interest
 #     3. Time-Series Correlation/Zmap Creation
-#     4. Seed zmap QC (push to highres (T1) and standard (MNI)
+#     4. Seed zmap QC (push to standard (MNI)
 ##################################################################################################################
 
 
@@ -693,29 +693,6 @@ EOF
         rm ${roi}.png
       fi
 
-      # Check for FieldMap registration correction
-      if [[ $fieldMapFlag == 1 ]]; then
-        # Nonlinear warp from EPI to T1
-        clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
-        applywarp --in=${rawEpiDir}/${roi}/cope1.nii \
-        --ref="$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz \
-        --out=${seedcorrDir}/${roi}_highres_zmap.nii.gz \
-        --warp="$rawEpiDir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
-        --datatype=float
-      else
-        # Affine Transform from EPI to T1
-        clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
-        flirt -in ${rawEpiDir}/${roi}/cope1.nii \
-        -ref "$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz \
-        -out ${seedcorrDir}/${roi}_highres_zmap.nii.gz \
-        -applyxfm -init "$rawEpiDir"/${nuisancefeat}/reg/example_func2highres.mat \
-        -datatype float
-      fi
-
-      # Mask out data with T1 mask (create temporary binary of skull-stripped T1)
-      fslmaths "$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz -bin "$rawEpiDir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
-      fslmaths ${seedcorrDir}/${roi}_highres_zmap.nii.gz -mas "$rawEpiDir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_highres_zmap_masked.nii.gz
-      rm "$rawEpiDir"/${nuisancefeat}/reg/highres_mask.nii.gz
 
       # Nonlinear warp from EPI to MNI
       clobber ${seedcorrDir}/${roi}_standard_zmap.nii.gz &&\
@@ -752,29 +729,6 @@ EOF
         rm ${roi}_ms.png
       fi
 
-      # Check for FieldMap registration correction
-      if [[ $fieldMapFlag == 1 ]]; then
-        # Nonlinear warp from EPI to T1
-        clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
-        applywarp --in=${rawEpiDir}/${roi}_ms/cope1.nii \
-        --ref="$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz \
-        --out=${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
-        --warp="$rawEpiDir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
-        --datatype=float
-      else
-        # Affine Transform from EPI to T1
-        clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
-        flirt -in ${rawEpiDir}/${roi}_ms/cope1.nii \
-        -ref "$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz \
-        -out ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
-        -applyxfm -init "$rawEpiDir"/${nuisancefeat}/reg/example_func2highres.mat \
-        -datatype float
-      fi
-
-      # Mask out data with T1 mask (create temporary binary of skull-stripped T1)
-      fslmaths "$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz -bin "$rawEpiDir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
-      fslmaths ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz -mas "$rawEpiDir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_ms_highres_zmap_masked.nii.gz
-      rm "$rawEpiDir"/${nuisancefeat}/reg/highres_mask.nii.gz
 
       # Nonlinear warp from EPI to MNI
       clobber ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz &&\
@@ -850,29 +804,6 @@ EOF
         rm ${roi}_ms.png
       fi
 
-      # Check for FieldMap registration correction
-      if [[ $fieldMapFlag == 1 ]]; then
-        # Nonlinear warp from EPI to T1
-        clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
-        applywarp --in=${rawEpiDir}/${roi}/cope1.nii \
-        --ref="$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz \
-        --out=${seedcorrDir}/${roi}_highres_zmap.nii.gz \
-        --warp="$rawEpiDir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
-        --datatype=float
-      else
-        # Affine Transform from EPI to T1
-        clobber ${seedcorrDir}/${roi}_highres_zmap.nii.gz &&\
-        flirt -in ${rawEpiDir}/${roi}/cope1.nii \
-        -ref "$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz \
-        -out ${seedcorrDir}/${roi}_highres_zmap.nii.gz \
-        -applyxfm -init "$rawEpiDir"/${nuisancefeat}/reg/example_func2highres.mat \
-        -datatype float
-      fi
-
-      # Mask out data with T1 mask (create temporary binary of skull-stripped T1)
-      fslmaths "$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz -bin "$rawEpiDir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
-      fslmaths ${seedcorrDir}/${roi}_highres_zmap.nii.gz -mas "$rawEpiDir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_highres_zmap_masked.nii.gz
-
       # Nonlinear warp from EPI to MNI
       clobber ${seedcorrDir}/${roi}_standard_zmap.nii.gz &&\
       applywarp --in=${rawEpiDir}/${roi}/cope1.nii \
@@ -894,29 +825,6 @@ EOF
 
 
       # Motionscrubbed data
-      # Check for FieldMap registration correction
-      if [[ $fieldMapFlag == 1 ]]; then
-        # Nonlinear warp from EPI to T1
-        clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
-        applywarp --in=${rawEpiDir}/${roi}_ms/cope1.nii \
-        --ref="$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz \
-        --out=${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
-        --warp="$rawEpiDir"/${nuisancefeat}/reg/example_func2highres_warp.nii.gz \
-        --datatype=float
-      else
-        # Affine Transform from EPI to T1
-        clobber ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz &&\
-        flirt -in ${rawEpiDir}/${roi}_ms/cope1.nii \
-        -ref "$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz \
-        -out ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz \
-        -applyxfm -init "$rawEpiDir"/${nuisancefeat}/reg/example_func2highres.mat \
-        -datatype float
-      fi
-
-      # Mask out data with T1 mask (remove temporary binary of skull-stripped T1)
-      fslmaths "$rawEpiDir"/${nuisancefeat}/reg/highres.nii.gz -bin "$rawEpiDir"/${nuisancefeat}/reg/highres_mask.nii.gz -odt char
-      fslmaths ${seedcorrDir}/${roi}_ms_highres_zmap.nii.gz -mas "$rawEpiDir"/${nuisancefeat}/reg/highres_mask.nii.gz ${seedcorrDir}/${roi}_ms_highres_zmap_masked.nii.gz
-      rm "$rawEpiDir"/${nuisancefeat}/reg/highres_mask.nii.gz
 
       # Nonlinear warp from EPI to MNI
       clobber ${seedcorrDir}/${roi}_ms_standard_zmap.nii.gz &&\


### PR DESCRIPTION
Changes proposed in this pull request
- enhanced arg parsing
- add flag for producing seedmaps (default behavior to extract timeseries only)
- if producing seedmaps, remove highres mapping
- if motionscrubbing, do both unscrubbed and scrubbed (no 0, 1, or 2 option like previously used).

Todo:
- make separate rois (rois_classic vs rois_compcor?) directory for distinguishing between classic and compcor roi timeseries.

Successful tests:
```
git checkout enh_seedVoxelCorrelation.sh
bash seedVoxelCorrelation.sh \
--epi=/Shared/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/test/sub-GEA161_ses-activepre/ica_aroma/denoised_func_data_nonaggr_bp_res4d_normandscaled.nii.gz \
--roiList=/Shared/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/seeds/seedlist.txt \
--compcor

bash seedVoxelCorrelation.sh \
--epi=/Shared/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/test/sub-GEA161_ses-activepre/ica_aroma/denoised_func_data_nonaggr_bp_res4d_normandscaled.nii.gz \
--roiList=/Shared/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/seeds/seedlist.txt \
--compcor --seedmaps
```