### PR TITLE
FIX: updated fix issue on scriptdir compatability

### DIFF
--- a/processRestingState_bids_wrapper.sh
+++ b/processRestingState_bids_wrapper.sh
@@ -131,7 +131,7 @@ in
     esac
 done
 
-scriptdir="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # if no user-defined roilist, default to first .nii.gz file found in ROIs dir
 if [[ "${roilist}" == "" ]]; then


### PR DESCRIPTION
Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)

----- REMOVE TILL HERE -----

Fixes # 89

Changes proposed in this pull request
Use DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )" 
as bash method for identifying full path do current directory within wrapper script
