### PR TITLE
ENH: Specify t1 path

### DIFF
--- a/processRestingState_bids_wrapper.sh
+++ b/processRestingState_bids_wrapper.sh
@@ -388,6 +388,7 @@ subjectT1_mask=$(basename ${t1_mask%%.nii*})
 
 # make the t1_brain image
 fslmaths ${t1} -mul ${t1_mask} ${subjectT1_dir}/${t1}_brain.nii.gz
+t1_brain="${subjectT1_dir}/${t1}_brain.nii.gz"
 
 
 if [[ "${fieldMapFlag}" = 1 ]]; then
@@ -404,11 +405,6 @@ if [[ "${fieldMapFlag}" = 1 ]]; then
   fi
 fi
  
- if [ -z "${T1_RPI}" ] || [ -z "${T1_RPI_brain}" ] || [ -z "${inFile}" ]; then
-  printf "\\n%s\\nERROR: at least one prerequisite scan is missing. Exiting.\\n" "$(date)" 1>&2
-  exit 1
-else
-
   softwareCheck # check dependencies
 
   printf "\\n%s\\nBeginning preprocesssing ...\\n" "$(date)"
@@ -416,9 +412,9 @@ else
   mkdir -p "${rsOut}"
 
   {
-  echo "t1=${T1_RPI_brain}"
-  echo "t1Skull=${T1_RPI}"
-  echo "t1Mask=${T1_brain_mask}"
+  echo "t1=${t1_brain}"
+  echo "t1Skull=${t1}"
+  echo "t1Mask=${t1_mask}"
   echo "peDir=-y"
   echo "epiDwell=${dwellTime}"
   echo "epiTR=2"
@@ -440,8 +436,8 @@ else
     fi
     
     "${scriptdir}"/qualityCheck.sh --epi="$(find "${rsOut}" -maxdepth 1 -type f -name "*rest_bold*.nii.gz")" \
-      --t1brain="${T1_RPI_brain}" \
-      --t1="${T1_RPI}" \
+      --t1brain="${t1_brain}" \
+      --t1="${t1}" \
       --fmap="${fmap_prepped}" \
       --fmapmag="${fmap_mag}" \
       --fmapmagbrain="${fmap_mag_stripped}" \
@@ -451,7 +447,7 @@ else
 
     clobber "${rsOut}"/preproc/nonfiltered_smooth_data.nii.gz &&\
     "${scriptdir}"/restingStatePreprocess.sh --epi="${rsOut}"/mcImg_stripped.nii.gz \
-      --t1brain="${T1_RPI_brain}" \
+      --t1brain="${t1_brain}" \
       --tr=2 \
       --te=30 \
       --smooth=6 \
@@ -462,8 +458,8 @@ else
     printf "Process without fieldmap."
     "${scriptdir}"/qualityCheck.sh \
       --epi="$(find "${rsOut}" -maxdepth 1 -type f -name "*rest_bold*.nii.gz")" \
-      --t1brain="${T1_RPI_brain}" \
-      --t1="${T1_RPI}" \
+      --t1brain="${t1_brain}" \
+      --t1="${t1}" \
       --dwelltime="${dwellTime}" \
       --pedir=-y \
       --regmode=6dof
@@ -471,7 +467,7 @@ else
     clobber "${rsOut}"/preproc/nonfiltered_smooth_data.nii.gz &&\
     "${scriptdir}"/restingStatePreprocess.sh \
       --epi="${rsOut}"/mcImg_stripped.nii.gz \
-      --t1brain="${T1_RPI_brain}" \
+      --t1brain="${t1_brain}" \
       --tr=2 \
       --te=30 \
       --smooth=6 \
@@ -498,7 +494,7 @@ else
   clobber "${epiDataFiltReg}" &&\
   "${scriptdir}/"removeNuisanceRegressor.sh \
     --epi="$epiDataFilt" \
-    --t1brain="${T1_RPI_brain}" \
+    --t1brain="${t1_brain}" \
     --nuisanceList="$rsOut"/nuisanceList.txt \
     --lp=.08 \
     --hp=.008 \

--- a/processRestingState_bids_wrapper.sh
+++ b/processRestingState_bids_wrapper.sh
@@ -321,18 +321,18 @@ in
       fi
       shift;;
   --t1)
-      inFile=`get_arg1 $1`;
-      export inFile;
-      if [ "$inFile" == "" ]; then
-        echo "Error: The restingStateImage (-E) is a required option"
+      t1=`get_arg1 $1`;
+      export t1;
+      if [ "$t1" == "" ]; then
+        echo "Error: T1 required"
         exit 1
       fi
       shift;;
   --t1_mask)
-      inFile=`get_arg1 $1`;
-      export inFile;
-      if [ "$inFile" == "" ]; then
-        echo "Error: The restingStateImage (-E) is a required option"
+      t1_mask=`get_arg1 $1`;
+      export t1_mask;
+      if [ "$t1_mask" == "" ]; then
+        echo "Error: T1 mask required"
         exit 1
       fi
       shift;;

--- a/processRestingState_bids_wrapper.sh
+++ b/processRestingState_bids_wrapper.sh
@@ -16,17 +16,17 @@ function Usage {
 ########## FSL's arg parsing functions ###################
 get_opt1() {
     arg=$(echo $1 | sed 's/=.*//')
-    echo $arg
+    echo "$arg"
 }
 
 get_imarg1() {
-    arg=$(get_arg1 $1);
-    arg=$($FSLDIR/bin/remove_ext $arg);
-    echo $arg
+    arg=$(get_arg1 "$1");
+    arg=$("$FSLDIR"/bin/remove_ext "$arg");
+    echo "$arg"
 }
 
 get_arg1() {
-    if [ X"`echo $1 | grep '='`" = X ] ; then
+    if [ X"$(echo $1 | grep '=')" = X ] ; then
 	echo "Option $1 requires an argument" 1>&2
 	exit 1
     else
@@ -35,7 +35,7 @@ get_arg1() {
 	    echo "Option $1 requires an argument" 1>&2
 	    exit 1
 	fi
-	echo $arg
+	echo "$arg"
     fi
 }
 
@@ -509,4 +509,3 @@ fi
 
   # prevents permissions denied error when others run new seeds
   parallel chmod 774 ::: "$(find "${rsOut}" -type f \( -name "highres2standard.nii.gz" -o -name "seeds*.txt" -o -name "rsParams*" -o -name "run*.m" -o -name "highres.nii.gz" -o -name "standard.nii.gz" -o -name "analysisResults.html" \))"
-fi

--- a/processRestingState_bids_wrapper.sh
+++ b/processRestingState_bids_wrapper.sh
@@ -96,6 +96,217 @@ function clobber()
 clob=false
 export -f clobber
 
+
+function RPI_orient() {
+    local infile=$1 &&\
+    [ ! -z  "${infile}" ] ||\
+    ( printf '%s\n' "${FUNCNAME[0]}, input not defined" && return 1 )
+
+    #Determine qform-orientation to properly reorient file to RPI (MNI) orientation
+	xorient=`fslhd ${infile} | grep "^qform_xorient" | awk '{print $2}' | cut -c1`
+	yorient=`fslhd ${infile} | grep "^qform_yorient" | awk '{print $2}' | cut -c1`
+	zorient=`fslhd ${infile} | grep "^qform_zorient" | awk '{print $2}' | cut -c1`
+
+	native_orient=${xorient}${yorient}${zorient}
+
+	echo "native orientation = ${native_orient}"
+
+	if [ "${native_orient}" != "RPI" ]; then
+
+	  case ${native_orient} in
+
+		#L PA IS
+		LPI)
+			flipFlag="-x y z"
+			;;
+		LPS)
+			flipFlag="-x y -z"
+	    		;;
+		LAI)
+			flipFlag="-x -y z"
+	    		;;
+		LAS)
+			flipFlag="-x -y -z"
+	    		;;
+
+		#R PA IS
+		RPS)
+			flipFlag="x y -z"
+	    		;;
+		RAI)
+			flipFlag="x -y z"
+	    		;;
+		RAS)
+			flipFlag="x -y -z"
+	    		;;
+
+		#L IS PA
+		LIP)
+			flipFlag="-x z y"
+	    		;;
+		LIA)
+			flipFlag="-x -z y"
+	    		;;
+		LSP)
+			flipFlag="-x z -y"
+	    		;;
+		LSA)
+			flipFlag="-x -z -y"
+	    		;;
+
+		#R IS PA
+		RIP)
+			flipFlag="x z y"
+	    		;;
+		RIA)
+			flipFlag="x -z y"
+	    		;;
+		RSP)
+			flipFlag="x z -y"
+	    		;;
+		RSA)
+			flipFlag="x -z -y"
+	    		;;
+
+		#P IS LR
+		PIL)
+			flipFlag="-z x y"
+	    		;;
+		PIR)
+			flipFlag="z x y"
+	    		;;
+		PSL)
+			flipFlag="-z x -y"
+	    		;;
+		PSR)
+			flipFlag="z x -y"
+	    		;;
+
+		#A IS LR
+		AIL)
+			flipFlag="-z -x y"
+	    		;;
+		AIR)
+			flipFlag="z -x y"
+	    		;;
+		ASL)
+			flipFlag="-z -x -y"
+	    		;;
+		ASR)
+			flipFlag="z -x -y"
+	    		;;
+
+		#P LR IS
+		PLI)
+			flipFlag="-y x z"
+	    		;;
+		PLS)
+			flipFlag="-y x -z"
+	    		;;
+		PRI)
+			flipFlag="y x z"
+	    		;;
+		PRS)
+			flipFlag="y x -z"
+	    		;;
+
+		#A LR IS
+		ALI)
+			flipFlag="-y -x z"
+	    		;;
+		ALS)
+			flipFlag="-y -x -z"
+	    		;;
+		ARI)
+			flipFlag="y -x z"
+	    		;;
+		ARS)
+			flipFlag="y -x -z"
+	    		;;
+
+		#I LR PA
+		ILP)
+			flipFlag="-y z x"
+	    		;;
+		ILA)
+			flipFlag="-y -z x"
+	    		;;
+		IRP)
+			flipFlag="y z x"
+	    		;;
+		IRA)
+			flipFlag="y -z x"
+	    		;;
+
+		#S LR PA
+		SLP)
+			flipFlag="-y z -x"
+	    		;;
+		SLA)
+			flipFlag="-y -z -x"
+	    		;;
+		SRP)
+			flipFlag="y z -x"
+	    		;;
+		SRA)
+			flipFlag="y -z -x"
+	    		;;
+
+		#I PA LR
+		IPL)
+			flipFlag="-z y x"
+	    		;;
+		IPR)
+			flipFlag="z y x"
+	    		;;
+		IAL)
+			flipFlag="-z -y x"
+	    		;;
+		IAR)
+			flipFlag="z -y x"
+	    		;;
+
+		#S PA LR
+		SPL)
+			flipFlag="-z y -x"
+	    		;;
+		SPR)
+			flipFlag="z y -x"
+	    		;;
+		SAL)
+			flipFlag="-z -y -x"
+	    		;;
+		SAR)
+			flipFlag="z -y -x"
+	    		;;
+	  esac
+
+	  echo "flipping by ${flipFlag}"
+
+	  #Reorienting image and checking for warning messages
+	  warnFlag=`fslswapdim ${infile} ${flipFlag} ${infile%.nii.gz}_RPI.nii.gz`
+	  warnFlagCut=`echo ${warnFlag} | awk -F":" '{print $1}'`
+
+	  #Reorienting the file may require swapping out the flag orientation to match the .img block
+	  if [[ $warnFlagCut == "WARNING" ]]; then
+		fslorient -swaporient ${infile%.nii.gz}_RPI.nii.gz
+	  fi
+
+	else
+
+	  echo "No need to reorient.  Dataset already in RPI orientation."
+
+	  if [ ! -e ${infile%.nii.gz}_RPI.nii.gz ]; then
+
+	    cp ${infile} ${infile%.nii.gz}_RPI.nii.gz
+
+	  fi
+
+	fi
+}
+
+
+
 if [ $# -lt 2 ] ; then Usage; exit 0; fi
 while [ $# -ge 1 ] ; do
   iarg=$(get_opt1 $1);
@@ -167,8 +378,8 @@ rsOut="${bidsDir}/derivatives/rsOut/sub-${subID}/ses-${sesID}"
 # load variables needed for processing
 
 # check orientation of t1 and change to RPI if needed
-
-
+RPI_orient ${t1}
+RPI_orient ${t1_mask}
 
 # t1
 subjectT1_dir=$(dirname ${t1})


### PR DESCRIPTION
Fixes # 88

Changes proposed in this pull request
- specify full path of the t1 and t1_mask that you want to use
- make an rsOut/anat directory where these are copied with a common filename and where all intermediate files will then go

example call 
```
/Users/mwvoss/bin/RestingState/processRestingState_bids_wrapper.sh \
--epi=/Volumes/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/sub-SEH1001/ses-pre/func/sub-SEH1001_ses-pre_task-rest_bold.nii.gz \
--t1=/Volumes/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/fmriprep/sub-SEH1001/ses-pre/anat/sub-SEH1001_ses-pre_T1w_preproc.nii.gz \
--t1_mask=/Volumes/vosslabhpc/Projects/Bike_ATrain/Imaging/BIDS/derivatives/fmriprep/sub-SEH1001/ses-pre/anat/sub-SEH1001_ses-pre_T1w_brainmask.nii.gz \
--roiList=/Users/mwvoss/bin/RestingState/ROIs/seedtest.txt \
--compcor
```
